### PR TITLE
fix: prevent mobile sidebar from auto-focusing on open

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -194,6 +194,7 @@ function Sidebar({
             } as React.CSSProperties
           }
           side={side}
+          onOpenAutoFocus={(event) => event.preventDefault()}
         >
           <SheetHeader className="sr-only">
             <SheetTitle>Sidebar</SheetTitle>


### PR DESCRIPTION
This PR fixes the issue where the search input in the sidebar auto-focuses on mobile when the sidebar is opened, even if `autoFocus={false}` is set. This is achieved by preventing the default behavior of Radix UI's `SheetContent` component on autofocus.