### PR TITLE
Rename feed "enabled" to "autoRefresh"

### DIFF
--- a/prisma/migrations/20260530000000_rename_enabled_to_auto_refresh/migration.sql
+++ b/prisma/migrations/20260530000000_rename_enabled_to_auto_refresh/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Feed" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "link" TEXT NOT NULL,
+    "lastFetched" DATETIME NOT NULL,
+    "titleFilterExpressions" TEXT NOT NULL DEFAULT '',
+    "autoRefresh" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "userId" TEXT NOT NULL,
+    "feedCategoryId" INTEGER,
+    CONSTRAINT "Feed_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Feed_feedCategoryId_fkey" FOREIGN KEY ("feedCategoryId") REFERENCES "FeedCategory" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Feed" ("id", "title", "link", "lastFetched", "titleFilterExpressions", "autoRefresh", "createdAt", "updatedAt", "userId", "feedCategoryId") SELECT "id", "title", "link", "lastFetched", "titleFilterExpressions", "enabled", "createdAt", "updatedAt", "userId", "feedCategoryId" FROM "Feed";
+DROP TABLE "Feed";
+ALTER TABLE "new_Feed" RENAME TO "Feed";
+CREATE UNIQUE INDEX "Feed_userId_link_key" ON "Feed"("userId", "link");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model Feed {
   link                   String
   lastFetched            DateTime
   titleFilterExpressions String        @default("")
-  enabled                Boolean       @default(true)
+  autoRefresh            Boolean       @default(true)
   createdAt              DateTime      @default(now())
   updatedAt              DateTime      @updatedAt
   articles               Article[]

--- a/src/components/feed/feed-form.tsx
+++ b/src/components/feed/feed-form.tsx
@@ -41,14 +41,14 @@ const FeedForm = ({ editFeed, onSubmitComplete }: FeedFormProps) => {
           link: editFeed.link,
           titleFilterExpressions: editFeed.titleFilterExpressions,
           feedCategoryId: editFeed.feedCategoryId ?? undefined,
-          enabled: editFeed.enabled,
+          autoRefresh: editFeed.autoRefresh,
         }
       : {
           title: "",
           link: "",
           titleFilterExpressions: "",
           feedCategoryId: undefined,
-          enabled: true,
+          autoRefresh: true,
         },
   });
 
@@ -170,13 +170,14 @@ const FeedForm = ({ editFeed, onSubmitComplete }: FeedFormProps) => {
 
           <FormField
             control={form.control}
-            name="enabled"
+            name="autoRefresh"
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between gap-2">
                 <div className="flex flex-col gap-1">
-                  <FormLabel>Enabled</FormLabel>
+                  <FormLabel>Refresh Automatically</FormLabel>
                   <p className="text-muted-foreground text-sm">
-                    Paused feeds are skipped during automatic refresh.
+                    When disabled, this feed is skipped during automatic
+                    refresh.
                   </p>
                 </div>
                 <FormControl>

--- a/src/components/navigation/feed-navigation.tsx
+++ b/src/components/navigation/feed-navigation.tsx
@@ -58,12 +58,12 @@ const FeedNavigation = async () => {
     feeds.map((feed) => (
       <SidebarMenuItem key={feed.id}>
         <AppSidebarMenuButton href={`/feed/${feed.id}`}>
-          {feed.enabled ? <NewspaperIcon /> : <PauseIcon />}
+          {feed.autoRefresh ? <NewspaperIcon /> : <PauseIcon />}
           <span
-            className={`grow truncate ${feed.enabled ? "" : "text-muted-foreground"}`}
+            className={`grow truncate ${feed.autoRefresh ? "" : "text-muted-foreground"}`}
           >
             {feed.title}
-            {!feed.enabled && <span className="sr-only"> (paused)</span>}
+            {!feed.autoRefresh && <span className="sr-only"> (paused)</span>}
           </span>
           {feed._count.articles > 0 && (
             <Badge variant="secondary">{feed._count.articles}</Badge>

--- a/src/lib/repository/feedRepository.ts
+++ b/src/lib/repository/feedRepository.ts
@@ -118,7 +118,7 @@ export const refreshFeed = async (feedId: number) => {
 
 export const refreshCategoryFeeds = async (categoryId: number) => {
   const feeds = await prisma.feed.findMany({
-    where: { feedCategoryId: categoryId, enabled: true },
+    where: { feedCategoryId: categoryId, autoRefresh: true },
     select: { id: true },
   });
 
@@ -140,7 +140,7 @@ export const refreshFeeds = async () => {
   logger.debug("Refreshing all feeds.");
 
   const feeds = await prisma.feed.findMany({
-    where: { enabled: true },
+    where: { autoRefresh: true },
     select: { id: true },
   });
 

--- a/src/lib/repository/feedSchema.ts
+++ b/src/lib/repository/feedSchema.ts
@@ -20,7 +20,7 @@ export const feedSchema = z.object({
     },
   ),
   feedCategoryId: z.number().optional(),
-  enabled: z.boolean(),
+  autoRefresh: z.boolean(),
 });
 export type FeedSchema = z.infer<typeof feedSchema>;
 

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -33,7 +33,7 @@ export const createFeed = (overrides: {
   userId: string;
   title?: string;
   link?: string;
-  enabled?: boolean;
+  autoRefresh?: boolean;
   titleFilterExpressions?: string;
   feedCategoryId?: number | null;
 }) => {
@@ -42,7 +42,7 @@ export const createFeed = (overrides: {
       userId: overrides.userId,
       title: overrides.title ?? "Test Feed",
       link: overrides.link ?? `https://example.com/${randomUUID()}.xml`,
-      enabled: overrides.enabled ?? true,
+      autoRefresh: overrides.autoRefresh ?? true,
       titleFilterExpressions: overrides.titleFilterExpressions ?? "",
       lastFetched: new Date(0),
       feedCategoryId: overrides.feedCategoryId ?? null,

--- a/tests/integration/factories.test.ts
+++ b/tests/integration/factories.test.ts
@@ -18,7 +18,7 @@ describe("factories", () => {
     const user = await createUser();
     const feed = await createFeed({ userId: user.id, title: "My Feed" });
     expect(feed.title).toBe("My Feed");
-    expect(feed.enabled).toBe(true);
+    expect(feed.autoRefresh).toBe(true);
   });
 
   it("creates an article on a feed", async () => {

--- a/tests/integration/feedRepository.test.ts
+++ b/tests/integration/feedRepository.test.ts
@@ -85,15 +85,15 @@ describe("feedRepository.refreshFeed", () => {
 });
 
 describe("feedRepository.refreshFeeds", () => {
-  it("refreshes only enabled feeds", async () => {
-    const enabled = await createFeed({
+  it("refreshes only auto-refresh feeds", async () => {
+    const autoRefreshed = await createFeed({
       userId,
-      enabled: true,
+      autoRefresh: true,
       link: "https://example.com/on.xml",
     });
-    const disabled = await createFeed({
+    const paused = await createFeed({
       userId,
-      enabled: false,
+      autoRefresh: false,
       link: "https://example.com/off.xml",
     });
     vi.mocked(scrapeFeed).mockImplementation(async (feed: Feed) => [
@@ -102,10 +102,10 @@ describe("feedRepository.refreshFeeds", () => {
 
     await refreshFeeds();
 
-    expect(await prisma.article.count({ where: { feedId: enabled.id } })).toBe(
-      1,
-    );
-    expect(await prisma.article.count({ where: { feedId: disabled.id } })).toBe(
+    expect(
+      await prisma.article.count({ where: { feedId: autoRefreshed.id } }),
+    ).toBe(1);
+    expect(await prisma.article.count({ where: { feedId: paused.id } })).toBe(
       0,
     );
   });
@@ -124,7 +124,7 @@ describe("feedRepository.createFeed", () => {
       title: "",
       link: "https://example.com/new.xml",
       titleFilterExpressions: "",
-      enabled: true,
+      autoRefresh: true,
     });
 
     const created = await prisma.feed.findFirstOrThrow({ where: { userId } });
@@ -143,14 +143,14 @@ describe("feedRepository.updateFeed", () => {
       title: "New",
       link: feed.link,
       titleFilterExpressions: "",
-      enabled: false,
+      autoRefresh: false,
     });
 
     const updated = await prisma.feed.findUniqueOrThrow({
       where: { id: feed.id },
     });
     expect(updated.title).toBe("New");
-    expect(updated.enabled).toBe(false);
+    expect(updated.autoRefresh).toBe(false);
   });
 });
 
@@ -209,23 +209,23 @@ describe("feedRepository categories", () => {
 });
 
 describe("feedRepository.refreshCategoryFeeds", () => {
-  it("refreshes only enabled feeds in the given category", async () => {
+  it("refreshes only auto-refresh feeds in the given category", async () => {
     const category = await createCategory({ userId, name: "Tech" });
     const inCategoryEnabled = await createFeed({
       userId,
-      enabled: true,
+      autoRefresh: true,
       feedCategoryId: category.id,
       link: "https://example.com/cat-on.xml",
     });
     const inCategoryDisabled = await createFeed({
       userId,
-      enabled: false,
+      autoRefresh: false,
       feedCategoryId: category.id,
       link: "https://example.com/cat-off.xml",
     });
     const outOfCategory = await createFeed({
       userId,
-      enabled: true,
+      autoRefresh: true,
       feedCategoryId: null,
       link: "https://example.com/no-cat.xml",
     });

--- a/tests/unit/feedSchema.test.ts
+++ b/tests/unit/feedSchema.test.ts
@@ -5,7 +5,7 @@ const validFeed = {
   title: "Example",
   link: "https://example.com/feed.xml",
   titleFilterExpressions: "",
-  enabled: true,
+  autoRefresh: true,
 };
 
 describe("feedSchema", () => {


### PR DESCRIPTION
## Summary
- Renames the confusing "Enabled" toggle to "Refresh Automatically" in the UI, and `enabled` → `autoRefresh` across the database column, Prisma schema, Zod schema, repository queries, and all tests.
- Includes a data-preserving SQLite migration that maps existing `enabled` values into the new `autoRefresh` column.
- All 42 tests pass, build succeeds, formatting is clean.

## Test plan
- [x] `npm test` — all 42 unit and integration tests pass
- [x] `npm run build` — Next.js production build succeeds
- [x] `npm run format:check` — formatting clean
- [ ] Verify the feed form shows "Refresh Automatically" label with updated description
- [ ] Verify sidebar shows pause icon for feeds with auto-refresh disabled
- [ ] Verify `prisma migrate deploy` applies cleanly on a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)