### PR TITLE
feat: show Comments link on article cards from RSS <comments> field

### DIFF
--- a/docs/superpowers/plans/2026-06-04-comments-link.md
+++ b/docs/superpowers/plans/2026-06-04-comments-link.md
@@ -1,25 +1,34 @@
 # Comments Link Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Show a "Comments" link button on article cards when the RSS feed item includes a `<comments>` URL, opening in a new tab.
+**Goal:** Show a "Comments" link button on article cards when the RSS feed item
+includes a `<comments>` URL, opening in a new tab.
 
-**Architecture:** Add `commentsLink String?` to the `Article` schema; extract the field from raw RSS XML in `scrapeFeed` via regex alongside the existing `parseFeed` call; pass it through to `prisma.article.create`; render a new `CommentsButton` component in `article-card-actions.tsx` conditionally when the field is present.
+**Architecture:** Add `commentsLink String?` to the `Article` schema; extract
+the field from raw RSS XML in `scrapeFeed` via regex alongside the existing
+`parseFeed` call; pass it through to `prisma.article.create`; render a new
+`CommentsButton` component in `article-card-actions.tsx` conditionally when the
+field is present.
 
-**Tech Stack:** Prisma (SQLite), Next.js Server Components, Vitest (unit + integration), TypeScript
+**Tech Stack:** Prisma (SQLite), Next.js Server Components, Vitest (unit +
+integration), TypeScript
 
 ---
 
 ## File Map
 
-| Action | File |
-|--------|------|
-| Modify | `prisma/schema.prisma` |
+| Action | File                                                                             |
+| ------ | -------------------------------------------------------------------------------- |
+| Modify | `prisma/schema.prisma`                                                           |
 | Create | `prisma/migrations/<timestamp>_add_comments_link/migration.sql` (auto-generated) |
-| Modify | `src/lib/scraper.ts` |
-| Modify | `tests/integration/feedRepository.test.ts` |
-| Create | `src/components/article/comments-button.tsx` |
-| Modify | `src/components/article/article-card-actions.tsx` |
+| Modify | `src/lib/scraper.ts`                                                             |
+| Modify | `tests/integration/feedRepository.test.ts`                                       |
+| Create | `src/components/article/comments-button.tsx`                                     |
+| Modify | `src/components/article/article-card-actions.tsx`                                |
 
 ---
 
@@ -38,11 +47,13 @@ Expected: `Switched to a new branch 'feat/comments-link'`
 ### Task 2: Add `commentsLink` to the Prisma schema and migrate
 
 **Files:**
+
 - Modify: `prisma/schema.prisma`
 
 - [ ] **Step 1: Add the field to the Article model**
 
-In `prisma/schema.prisma`, find the `Article` model and add `commentsLink` after `link`:
+In `prisma/schema.prisma`, find the `Article` model and add `commentsLink` after
+`link`:
 
 ```prisma
 model Article {
@@ -75,7 +86,8 @@ model Article {
 npm run prisma:migrate-dev -- --name add_comments_link
 ```
 
-Expected output includes: `The following migration(s) have been applied` and `✓ Generated Prisma Client`
+Expected output includes: `The following migration(s) have been applied` and
+`✓ Generated Prisma Client`
 
 - [ ] **Step 3: Commit**
 
@@ -89,11 +101,13 @@ git commit -m "feat: add commentsLink field to Article schema"
 ### Task 3: Extract `<comments>` in `scrapeFeed` and update the return type
 
 **Files:**
+
 - Modify: `src/lib/scraper.ts`
 
 - [ ] **Step 1: Update the `scrapeFeed` function**
 
-Replace the entire `scrapeFeed` function in `src/lib/scraper.ts` (lines 73–106) with:
+Replace the entire `scrapeFeed` function in `src/lib/scraper.ts` (lines 73–106)
+with:
 
 ```typescript
 export const scrapeFeed = async (feed: Feed) => {
@@ -108,9 +122,9 @@ export const scrapeFeed = async (feed: Feed) => {
     throw new Error("Unable to parse feed.");
   }
 
-  const commentsUrls = [...fetchedFeed.matchAll(/<comments>(.*?)<\/comments>/gs)].map(
-    (m) => m[1].trim(),
-  );
+  const commentsUrls = [
+    ...fetchedFeed.matchAll(/<comments>(.*?)<\/comments>/gs),
+  ].map((m) => m[1].trim());
 
   const validFeedItems: Pick<
     Article,
@@ -157,9 +171,12 @@ git commit -m "feat: extract <comments> URL from RSS feed items"
 ### Task 4: Add unit tests for `<comments>` extraction in `scrapeFeed`
 
 **Files:**
+
 - Create: `tests/unit/scraper.test.ts`
 
-The existing integration tests mock `scrapeFeed` entirely, so we need a unit test that exercises the extraction logic directly. We mock `fetch` and `parseFeed` to control the inputs.
+The existing integration tests mock `scrapeFeed` entirely, so we need a unit
+test that exercises the extraction logic directly. We mock `fetch` and
+`parseFeed` to control the inputs.
 
 - [ ] **Step 1: Create the test file**
 
@@ -219,7 +236,10 @@ describe("scrapeFeed", () => {
         </item>
       </channel></rss>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "rss2",
       id: "",
@@ -245,7 +265,10 @@ describe("scrapeFeed", () => {
         </item>
       </channel></rss>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "rss2",
       id: "",
@@ -274,7 +297,10 @@ describe("scrapeFeed", () => {
         </item>
       </channel></rss>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "rss2",
       id: "",
@@ -303,7 +329,10 @@ describe("scrapeFeed", () => {
         </entry>
       </feed>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "atom",
       id: "",
@@ -341,13 +370,17 @@ git commit -m "test: unit tests for commentsLink extraction in scrapeFeed"
 ### Task 5: Update the integration test helper to include `commentsLink`
 
 **Files:**
+
 - Modify: `tests/integration/feedRepository.test.ts`
 
-The `feedItem` helper in the integration test returns a mock `scrapeFeed` result. It needs `commentsLink` to match the updated return type, so existing tests don't get TypeScript errors.
+The `feedItem` helper in the integration test returns a mock `scrapeFeed`
+result. It needs `commentsLink` to match the updated return type, so existing
+tests don't get TypeScript errors.
 
 - [ ] **Step 1: Update the `feedItem` helper**
 
-In `tests/integration/feedRepository.test.ts`, update the `feedItem` helper (lines 36–41):
+In `tests/integration/feedRepository.test.ts`, update the `feedItem` helper
+(lines 36–41):
 
 ```typescript
 const feedItem = (title: string, link: string) => ({
@@ -379,6 +412,7 @@ git commit -m "test: add commentsLink to feedItem helper"
 ### Task 6: Create the `CommentsButton` component
 
 **Files:**
+
 - Create: `src/components/article/comments-button.tsx`
 
 - [ ] **Step 1: Create the component**
@@ -441,11 +475,14 @@ git commit -m "feat: add CommentsButton component"
 ### Task 7: Wire `CommentsButton` into `article-card-actions.tsx`
 
 **Files:**
+
 - Modify: `src/components/article/article-card-actions.tsx`
 
 - [ ] **Step 1: Import and place `CommentsButton`**
 
-In `src/components/article/article-card-actions.tsx`, add the import and place `<CommentsButton>` immediately after `<VisitButton>`. The full file should look like:
+In `src/components/article/article-card-actions.tsx`, add the import and place
+`<CommentsButton>` immediately after `<VisitButton>`. The full file should look
+like:
 
 ```typescript
 "use client";
@@ -528,9 +565,12 @@ git commit -m "feat: show CommentsButton in article card actions"
 npm run dev
 ```
 
-- [ ] **Step 2: Open an RSS feed that includes `<comments>` elements** (e.g. `https://hnrss.org/show?points=100`) and verify:
-  - Articles with a `<comments>` URL show a "Comments" button to the right of "Visit Original"
+- [ ] **Step 2: Open an RSS feed that includes `<comments>` elements** (e.g.
+      `https://hnrss.org/show?points=100`) and verify:
+  - Articles with a `<comments>` URL show a "Comments" button to the right of
+    "Visit Original"
   - Clicking it opens the comments URL in a new tab
   - Articles without a `<comments>` URL show no button
 
-- [ ] **Step 3: Open an Atom feed and verify no "Comments" button appears on any article**
+- [ ] **Step 3: Open an Atom feed and verify no "Comments" button appears on any
+      article**

--- a/docs/superpowers/plans/2026-06-04-comments-link.md
+++ b/docs/superpowers/plans/2026-06-04-comments-link.md
@@ -1,0 +1,536 @@
+# Comments Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a "Comments" link button on article cards when the RSS feed item includes a `<comments>` URL, opening in a new tab.
+
+**Architecture:** Add `commentsLink String?` to the `Article` schema; extract the field from raw RSS XML in `scrapeFeed` via regex alongside the existing `parseFeed` call; pass it through to `prisma.article.create`; render a new `CommentsButton` component in `article-card-actions.tsx` conditionally when the field is present.
+
+**Tech Stack:** Prisma (SQLite), Next.js Server Components, Vitest (unit + integration), TypeScript
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `prisma/schema.prisma` |
+| Create | `prisma/migrations/<timestamp>_add_comments_link/migration.sql` (auto-generated) |
+| Modify | `src/lib/scraper.ts` |
+| Modify | `tests/integration/feedRepository.test.ts` |
+| Create | `src/components/article/comments-button.tsx` |
+| Modify | `src/components/article/article-card-actions.tsx` |
+
+---
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Create and switch to a new branch**
+
+```bash
+git checkout -b feat/comments-link
+```
+
+Expected: `Switched to a new branch 'feat/comments-link'`
+
+---
+
+### Task 2: Add `commentsLink` to the Prisma schema and migrate
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+
+- [ ] **Step 1: Add the field to the Article model**
+
+In `prisma/schema.prisma`, find the `Article` model and add `commentsLink` after `link`:
+
+```prisma
+model Article {
+  id              Int            @id @default(autoincrement())
+  title           String
+  publicationDate DateTime
+  description     String?
+  content         String?
+  link            String
+  commentsLink    String?
+  readAt          DateTime?
+  readLater       Boolean        @default(false)
+  starred         Boolean        @default(false)
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+  feedId          Int
+  feed            Feed           @relation(fields: [feedId], references: [id], onDelete: Cascade)
+  scrape          ArticleScrape?
+  lead            ArticleLead?
+  userId          String
+  user            User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, feedId, link])
+}
+```
+
+- [ ] **Step 2: Run the migration**
+
+```bash
+npm run prisma:migrate-dev -- --name add_comments_link
+```
+
+Expected output includes: `The following migration(s) have been applied` and `✓ Generated Prisma Client`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/
+git commit -m "feat: add commentsLink field to Article schema"
+```
+
+---
+
+### Task 3: Extract `<comments>` in `scrapeFeed` and update the return type
+
+**Files:**
+- Modify: `src/lib/scraper.ts`
+
+- [ ] **Step 1: Update the `scrapeFeed` function**
+
+Replace the entire `scrapeFeed` function in `src/lib/scraper.ts` (lines 73–106) with:
+
+```typescript
+export const scrapeFeed = async (feed: Feed) => {
+  const fetchedFeed = await fetch(feed.link).then((res) => res.text());
+  const parsedFeed = parseFeed(fetchedFeed);
+  if (!parsedFeed) {
+    logger.error(
+      { feed: { id: feed.id, title: feed.title, link: feed.link } },
+      "Unable to parse feed.",
+    );
+
+    throw new Error("Unable to parse feed.");
+  }
+
+  const commentsUrls = [...fetchedFeed.matchAll(/<comments>(.*?)<\/comments>/gs)].map(
+    (m) => m[1].trim(),
+  );
+
+  const validFeedItems: Pick<
+    Article,
+    "title" | "link" | "description" | "publicationDate" | "commentsLink"
+  >[] = [];
+  parsedFeed.items.forEach((item, index) => {
+    if (!item.title || !item.link || !item.pubDate) {
+      logger.error({ item }, "Invalid feed item.");
+    } else {
+      validFeedItems.push({
+        title: item.title,
+        link: item.link,
+        description: item.description ? item.description : null,
+        publicationDate: new Date(item.pubDate),
+        commentsLink: commentsUrls[index] ?? null,
+      });
+    }
+  });
+
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - ARTICLE_RETENTION_DAYS);
+
+  return validFeedItems.filter((item) => item.publicationDate >= thirtyDaysAgo);
+};
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/scraper.ts
+git commit -m "feat: extract <comments> URL from RSS feed items"
+```
+
+---
+
+### Task 4: Add unit tests for `<comments>` extraction in `scrapeFeed`
+
+**Files:**
+- Create: `tests/unit/scraper.test.ts`
+
+The existing integration tests mock `scrapeFeed` entirely, so we need a unit test that exercises the extraction logic directly. We mock `fetch` and `parseFeed` to control the inputs.
+
+- [ ] **Step 1: Create the test file**
+
+Create `tests/unit/scraper.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("htmlparser2", () => ({
+  parseFeed: vi.fn(),
+}));
+
+vi.mock("@/lib/prismaClient", () => ({ default: {} }));
+vi.mock("@/lib/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/lib/ai/services/leadService", () => ({ generateAiLead: vi.fn() }));
+
+import { parseFeed } from "htmlparser2";
+import { scrapeFeed } from "@/lib/scraper";
+import type { Feed } from "@prisma/client";
+
+const makeFeed = (link = "https://example.com/feed.xml"): Feed =>
+  ({
+    id: 1,
+    title: "Test Feed",
+    link,
+    userId: "user-1",
+    autoRefresh: true,
+    lastFetched: new Date(0),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    titleFilterExpressions: "",
+    feedCategoryId: null,
+  }) as Feed;
+
+const makeRssItem = (title: string, link: string) => ({
+  title,
+  link,
+  description: "desc",
+  pubDate: new Date(),
+  media: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("scrapeFeed", () => {
+  it("returns commentsLink when RSS item has <comments> element", async () => {
+    const xml = `
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <comments>https://example.com/1#comments</comments>
+        </item>
+      </channel></rss>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "rss2",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Article 1", "https://example.com/1")],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items).toHaveLength(1);
+    expect(items[0].commentsLink).toBe("https://example.com/1#comments");
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null commentsLink when RSS item has no <comments> element", async () => {
+    const xml = `
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+        </item>
+      </channel></rss>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "rss2",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Article 1", "https://example.com/1")],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items).toHaveLength(1);
+    expect(items[0].commentsLink).toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it("assigns commentsLink by position — item without comments gets null", async () => {
+    const xml = `
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <comments>https://example.com/1#comments</comments>
+        </item>
+        <item>
+          <title>Article 2</title>
+        </item>
+      </channel></rss>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "rss2",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [
+        makeRssItem("Article 1", "https://example.com/1"),
+        makeRssItem("Article 2", "https://example.com/2"),
+      ],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].commentsLink).toBe("https://example.com/1#comments");
+    expect(items[1].commentsLink).toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null commentsLink for Atom feeds (no <comments> element)", async () => {
+    const xml = `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <title>Atom Article</title>
+          <link href="https://example.com/atom/1"/>
+        </entry>
+      </feed>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "atom",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Atom Article", "https://example.com/atom/1")],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].commentsLink).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+```bash
+npm test -- tests/unit/scraper.test.ts
+```
+
+Expected: `4 tests passed`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/scraper.test.ts
+git commit -m "test: unit tests for commentsLink extraction in scrapeFeed"
+```
+
+---
+
+### Task 5: Update the integration test helper to include `commentsLink`
+
+**Files:**
+- Modify: `tests/integration/feedRepository.test.ts`
+
+The `feedItem` helper in the integration test returns a mock `scrapeFeed` result. It needs `commentsLink` to match the updated return type, so existing tests don't get TypeScript errors.
+
+- [ ] **Step 1: Update the `feedItem` helper**
+
+In `tests/integration/feedRepository.test.ts`, update the `feedItem` helper (lines 36–41):
+
+```typescript
+const feedItem = (title: string, link: string) => ({
+  title,
+  link,
+  description: null,
+  publicationDate: new Date(),
+  commentsLink: null,
+});
+```
+
+- [ ] **Step 2: Run all tests to verify nothing broke**
+
+```bash
+npm test
+```
+
+Expected: all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/feedRepository.test.ts
+git commit -m "test: add commentsLink to feedItem helper"
+```
+
+---
+
+### Task 6: Create the `CommentsButton` component
+
+**Files:**
+- Create: `src/components/article/comments-button.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/article/comments-button.tsx`:
+
+```typescript
+"use client";
+
+import { buttonVariants } from "@/components/ui/button";
+import { Article } from "@prisma/client";
+import { MessageSquare } from "lucide-react";
+import Link from "next/link";
+
+interface CommentsButtonProps {
+  article: Pick<Article, "commentsLink">;
+  size?: "sm" | "default" | "lg" | "icon";
+}
+
+const CommentsButton = ({ article }: CommentsButtonProps) => {
+  if (!article.commentsLink) return null;
+
+  return (
+    <Link
+      className={buttonVariants({
+        className: "text-xs",
+        size: "sm",
+        variant: "ghost",
+      })}
+      href={article.commentsLink}
+      target="_blank"
+      referrerPolicy="no-referrer"
+    >
+      <MessageSquare className="mr-1 size-4" />
+      Comments
+    </Link>
+  );
+};
+
+export default CommentsButton;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/article/comments-button.tsx
+git commit -m "feat: add CommentsButton component"
+```
+
+---
+
+### Task 7: Wire `CommentsButton` into `article-card-actions.tsx`
+
+**Files:**
+- Modify: `src/components/article/article-card-actions.tsx`
+
+- [ ] **Step 1: Import and place `CommentsButton`**
+
+In `src/components/article/article-card-actions.tsx`, add the import and place `<CommentsButton>` immediately after `<VisitButton>`. The full file should look like:
+
+```typescript
+"use client";
+
+import AiSummaryButton from "@/components/article/ai-summary-button";
+import CommentsButton from "@/components/article/comments-button";
+import ToggleReadButton from "@/components/article/toggle-read-button";
+import ToggleReadLaterButton from "@/components/article/toggle-read-later-button";
+import ToggleStarredButton from "@/components/article/toggle-starred-button";
+import VisitButton from "@/components/article/visit-button";
+import BackButton from "@/components/navigation/back-button";
+import { Separator } from "@/components/ui/separator";
+import { Prisma } from "@prisma/client";
+
+interface ArticleCardActionsProps {
+  article: Prisma.ArticleGetPayload<{
+    include: { feed: true; scrape: true };
+  }>;
+  hideAiSummary?: boolean;
+  showBackButton?: boolean;
+}
+
+const ArticleCardActions = (props: ArticleCardActionsProps) => (
+  <div className="grid w-full grid-cols-2 justify-items-start gap-y-1 md:flex md:w-auto md:grid-cols-none">
+    {props.showBackButton && (
+      <>
+        <BackButton />
+        <Separator className="mx-1 h-auto py-4" orientation="vertical" />
+      </>
+    )}
+
+    <ToggleReadButton article={props.article} />
+    <VisitButton article={props.article} size="sm" />
+    <CommentsButton article={props.article} />
+    {!props.hideAiSummary && (
+      <AiSummaryButton
+        feedId={props.article.feedId}
+        articleId={props.article.id}
+        size="sm"
+      />
+    )}
+    <ToggleReadLaterButton article={props.article} />
+    <ToggleStarredButton article={props.article} />
+  </div>
+);
+
+export default ArticleCardActions;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/article/article-card-actions.tsx
+git commit -m "feat: show CommentsButton in article card actions"
+```
+
+---
+
+### Task 8: Verify in the browser
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Open an RSS feed that includes `<comments>` elements** (e.g. `https://hnrss.org/show?points=100`) and verify:
+  - Articles with a `<comments>` URL show a "Comments" button to the right of "Visit Original"
+  - Clicking it opens the comments URL in a new tab
+  - Articles without a `<comments>` URL show no button
+
+- [ ] **Step 3: Open an Atom feed and verify no "Comments" button appears on any article**

--- a/docs/superpowers/specs/2026-06-04-comments-link-design.md
+++ b/docs/superpowers/specs/2026-06-04-comments-link-design.md
@@ -4,7 +4,10 @@
 
 ## Overview
 
-Add a "Comments" link button to article cards that opens the RSS `<comments>` URL in a new tab. The button is only shown when the RSS item includes a `<comments>` element. Atom feeds do not have this field and will never show the button.
+Add a "Comments" link button to article cards that opens the RSS `<comments>`
+URL in a new tab. The button is only shown when the RSS item includes a
+`<comments>` element. Atom feeds do not have this field and will never show the
+button.
 
 ## Data Layer
 
@@ -20,21 +23,30 @@ Run a Prisma migration to apply the schema change.
 
 **File:** `src/lib/scraper.ts`
 
-After calling `parseFeed(fetchedFeed)`, extract all `<comments>` URLs from the raw XML string using a regex over all `<comments>...</comments>` occurrences. Collect results into an array and zip by index with `parsedFeed.items`. Item `i` receives `commentsUrls[i]` or `undefined` if absent.
+After calling `parseFeed(fetchedFeed)`, extract all `<comments>` URLs from the
+raw XML string using a regex over all `<comments>...</comments>` occurrences.
+Collect results into an array and zip by index with `parsedFeed.items`. Item `i`
+receives `commentsUrls[i]` or `undefined` if absent.
 
-The extracted URL is included in the `validFeedItems` entries alongside `title`, `link`, `description`, and `publicationDate`. Atom feeds produce no matches and all items get `undefined`.
+The extracted URL is included in the `validFeedItems` entries alongside `title`,
+`link`, `description`, and `publicationDate`. Atom feeds produce no matches and
+all items get `undefined`.
 
 ## Storage Layer
 
 **File:** `src/lib/repository/feedRepository.ts`
 
-Pass `commentsLink` through to `prisma.article.create()`. No other changes needed.
+Pass `commentsLink` through to `prisma.article.create()`. No other changes
+needed.
 
 ## UI Layer
 
 **New component:** `src/components/article/comments-button.tsx`
 
-Mirrors `VisitButton`. Renders only when `article.commentsLink` is truthy. Opens in a new tab with `target="_blank"` and `referrerPolicy="no-referrer"`. Uses the same ghost/sm button variant and an appropriate icon (e.g. `MessageSquare` from lucide-react).
+Mirrors `VisitButton`. Renders only when `article.commentsLink` is truthy. Opens
+in a new tab with `target="_blank"` and `referrerPolicy="no-referrer"`. Uses the
+same ghost/sm button variant and an appropriate icon (e.g. `MessageSquare` from
+lucide-react).
 
 **Modified:** `src/components/article/article-card-actions.tsx`
 

--- a/docs/superpowers/specs/2026-06-04-comments-link-design.md
+++ b/docs/superpowers/specs/2026-06-04-comments-link-design.md
@@ -1,0 +1,47 @@
+# Comments Link Feature Design
+
+**Date:** 2026-06-04
+
+## Overview
+
+Add a "Comments" link button to article cards that opens the RSS `<comments>` URL in a new tab. The button is only shown when the RSS item includes a `<comments>` element. Atom feeds do not have this field and will never show the button.
+
+## Data Layer
+
+Add an optional column to the `Article` model in `prisma/schema.prisma`:
+
+```prisma
+commentsLink String?
+```
+
+Run a Prisma migration to apply the schema change.
+
+## Parsing Layer
+
+**File:** `src/lib/scraper.ts`
+
+After calling `parseFeed(fetchedFeed)`, extract all `<comments>` URLs from the raw XML string using a regex over all `<comments>...</comments>` occurrences. Collect results into an array and zip by index with `parsedFeed.items`. Item `i` receives `commentsUrls[i]` or `undefined` if absent.
+
+The extracted URL is included in the `validFeedItems` entries alongside `title`, `link`, `description`, and `publicationDate`. Atom feeds produce no matches and all items get `undefined`.
+
+## Storage Layer
+
+**File:** `src/lib/repository/feedRepository.ts`
+
+Pass `commentsLink` through to `prisma.article.create()`. No other changes needed.
+
+## UI Layer
+
+**New component:** `src/components/article/comments-button.tsx`
+
+Mirrors `VisitButton`. Renders only when `article.commentsLink` is truthy. Opens in a new tab with `target="_blank"` and `referrerPolicy="no-referrer"`. Uses the same ghost/sm button variant and an appropriate icon (e.g. `MessageSquare` from lucide-react).
+
+**Modified:** `src/components/article/article-card-actions.tsx`
+
+Place `<CommentsButton>` immediately to the right of `<VisitButton>`.
+
+## Out of Scope
+
+- Atom feed comments support (no equivalent field in the spec)
+- Backfilling existing articles with comments URLs
+- Marking articles as read when clicking the comments link

--- a/prisma/migrations/20260604124140_add_comments_link/migration.sql
+++ b/prisma/migrations/20260604124140_add_comments_link/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN "commentsLink" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model Article {
   description     String?
   content         String?
   link            String
+  commentsLink    String?
   readAt          DateTime?
   readLater       Boolean        @default(false)
   starred         Boolean        @default(false)

--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import AiSummaryButton from "@/components/article/ai-summary-button";
+import CommentsButton from "@/components/article/comments-button";
 import ToggleReadButton from "@/components/article/toggle-read-button";
 import ToggleReadLaterButton from "@/components/article/toggle-read-later-button";
 import ToggleStarredButton from "@/components/article/toggle-starred-button";
@@ -30,6 +31,8 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
     <ToggleReadButton article={props.article} />
 
     <VisitButton article={props.article} size="sm" />
+
+    <CommentsButton article={props.article} />
 
     {!props.hideAiSummary && (
       <AiSummaryButton

--- a/src/components/article/comments-button.tsx
+++ b/src/components/article/comments-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { buttonVariants } from "@/components/ui/button";
+import { Article } from "@prisma/client";
+import { MessageSquare } from "lucide-react";
+import Link from "next/link";
+
+interface CommentsButtonProps {
+  article: Pick<Article, "commentsLink">;
+}
+
+const CommentsButton = ({ article }: CommentsButtonProps) => {
+  if (!article.commentsLink) return null;
+
+  return (
+    <Link
+      className={buttonVariants({
+        className: "text-xs",
+        size: "sm",
+        variant: "ghost",
+      })}
+      href={article.commentsLink}
+      target="_blank"
+      referrerPolicy="no-referrer"
+    >
+      <MessageSquare className="mr-1 size-4" />
+      Comments
+    </Link>
+  );
+};
+
+export default CommentsButton;

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -82,11 +82,20 @@ export const scrapeFeed = async (feed: Feed) => {
     throw new Error("Unable to parse feed.");
   }
 
+  const itemBlocks = [...fetchedFeed.matchAll(/<item[\s>](.*?)<\/item>/gs)].map(
+    (m) => m[0],
+  );
+
+  const commentsUrls = itemBlocks.map((block) => {
+    const match = block.match(/<comments>(.*?)<\/comments>/s);
+    return match ? match[1].trim() : null;
+  });
+
   const validFeedItems: Pick<
     Article,
-    "title" | "link" | "description" | "publicationDate"
+    "title" | "link" | "description" | "publicationDate" | "commentsLink"
   >[] = [];
-  parsedFeed.items.forEach((item) => {
+  parsedFeed.items.forEach((item, index) => {
     if (!item.title || !item.link || !item.pubDate) {
       logger.error({ item }, "Invalid feed item.");
     } else {
@@ -95,6 +104,7 @@ export const scrapeFeed = async (feed: Feed) => {
         link: item.link,
         description: item.description ? item.description : null,
         publicationDate: new Date(item.pubDate),
+        commentsLink: commentsUrls[index] ?? null,
       });
     }
   });

--- a/tests/integration/feedRepository.test.ts
+++ b/tests/integration/feedRepository.test.ts
@@ -38,6 +38,7 @@ const feedItem = (title: string, link: string) => ({
   link,
   description: null,
   publicationDate: new Date(),
+  commentsLink: null,
 });
 
 beforeEach(async () => {

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -26,9 +26,9 @@ vi.mock("@/lib/logger", () => ({
 }));
 vi.mock("@/lib/ai/services/leadService", () => ({ generateAiLead: vi.fn() }));
 
-import { parseFeed } from "htmlparser2";
 import { scrapeFeed } from "@/lib/scraper";
 import type { Feed } from "@prisma/client";
+import { parseFeed } from "htmlparser2";
 
 const makeFeed = (link = "https://example.com/feed.xml"): Feed =>
   ({
@@ -67,7 +67,10 @@ describe("scrapeFeed", () => {
         </item>
       </channel></rss>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "rss2",
       id: "",
@@ -93,7 +96,10 @@ describe("scrapeFeed", () => {
         </item>
       </channel></rss>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "rss2",
       id: "",
@@ -124,7 +130,10 @@ describe("scrapeFeed", () => {
         </item>
       </channel></rss>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "rss2",
       id: "",
@@ -153,7 +162,10 @@ describe("scrapeFeed", () => {
         </entry>
       </feed>
     `;
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
     vi.mocked(parseFeed).mockReturnValue({
       type: "atom",
       id: "",

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("htmlparser2", () => ({
+  parseFeed: vi.fn(),
+}));
+
+vi.mock("@/lib/prismaClient", () => {
+  const deleteMany = vi.fn().mockResolvedValue({ count: 0 });
+  return {
+    default: {
+      articleLead: { deleteMany },
+      articleScrape: { deleteMany },
+      tokenUsage: { deleteMany },
+      article: { deleteMany },
+      feed: { deleteMany },
+      feedCategory: { deleteMany },
+      session: { deleteMany },
+      account: { deleteMany },
+      verification: { deleteMany },
+      user: { deleteMany },
+    },
+  };
+});
+vi.mock("@/lib/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("@/lib/ai/services/leadService", () => ({ generateAiLead: vi.fn() }));
+
+import { parseFeed } from "htmlparser2";
+import { scrapeFeed } from "@/lib/scraper";
+import type { Feed } from "@prisma/client";
+
+const makeFeed = (link = "https://example.com/feed.xml"): Feed =>
+  ({
+    id: 1,
+    title: "Test Feed",
+    link,
+    userId: "user-1",
+    autoRefresh: true,
+    lastFetched: new Date(0),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    titleFilterExpressions: "",
+    feedCategoryId: null,
+  }) as Feed;
+
+const makeRssItem = (title: string, link: string) => ({
+  title,
+  link,
+  description: "desc",
+  pubDate: new Date(),
+  media: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("scrapeFeed", () => {
+  it("returns commentsLink when RSS item has <comments> element", async () => {
+    const xml = `
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <comments>https://example.com/1#comments</comments>
+        </item>
+      </channel></rss>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "rss2",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Article 1", "https://example.com/1")],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items).toHaveLength(1);
+    expect(items[0].commentsLink).toBe("https://example.com/1#comments");
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null commentsLink when RSS item has no <comments> element", async () => {
+    const xml = `
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+        </item>
+      </channel></rss>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "rss2",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Article 1", "https://example.com/1")],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items).toHaveLength(1);
+    expect(items[0].commentsLink).toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it("assigns commentsLink correctly when only some items have <comments>", async () => {
+    const xml = `
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <comments>https://example.com/1#comments</comments>
+        </item>
+        <item>
+          <title>Article 2</title>
+          <link>https://example.com/2</link>
+        </item>
+      </channel></rss>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "rss2",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [
+        makeRssItem("Article 1", "https://example.com/1"),
+        makeRssItem("Article 2", "https://example.com/2"),
+      ],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].commentsLink).toBe("https://example.com/1#comments");
+    expect(items[1].commentsLink).toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null commentsLink for Atom feeds (no <comments> element)", async () => {
+    const xml = `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <title>Atom Article</title>
+          <link href="https://example.com/atom/1"/>
+        </entry>
+      </feed>
+    `;
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(xml)));
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "atom",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Atom Article", "https://example.com/atom/1")],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].commentsLink).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `commentsLink String?` to the `Article` schema and migrates the database
- Extracts `<comments>` URLs from raw RSS XML per-item (regex on individual `<item>` blocks, not global, to avoid index drift when only some items have the field); Atom feeds produce no matches and get `null`
- Adds a `CommentsButton` component that renders only when `commentsLink` is present, opening in a new tab with `target="_blank"` and `referrerPolicy="no-referrer"`
- Places `CommentsButton` immediately to the right of `Visit Original` in article card actions

## Test Plan

- [ ] Unit tests for `scrapeFeed` comments extraction pass (`tests/unit/scraper.test.ts` — 4 tests covering: present, absent, mixed items, Atom feed)
- [ ] All 46 tests pass (`npm test`)
- [ ] Add an RSS feed that includes `<comments>` elements (e.g. `https://hnrss.org/show?points=100`) and verify the Comments button appears to the right of Visit Original
- [ ] Verify clicking Comments opens the HN thread in a new tab
- [ ] Verify articles without a `<comments>` element show no Comments button
- [ ] Add an Atom feed and verify no Comments button appears on any article

🤖 Generated with [Claude Code](https://claude.com/claude-code)