### PR TITLE
docs: add git workflow and commit guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,10 @@ Standard flow:
 3. Push the branch.
 4. Open a PR against `main` with `gh pr create`. The PR title should follow
    Conventional Commits too, since squash-merges use it as the commit message.
-5. Wait for CI (`format-check`, `lint`, `test`, `build`) to pass, then merge.
+5. Wait for CI (`format-check`, `lint`, `test`, `build`) to pass.
+6. The user reviews the PR before it can be merged. The user will either merge
+   the PR themselves or explicitly instruct the agent to merge it. Do **not**
+   merge a PR without that explicit instruction, even after CI passes.
 
 If any check fails, fix the underlying issue and re-push. Do **not** bypass with
 `git commit --no-verify`, `gh pr merge --admin`, or by disabling the failing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,63 @@ npm run lint    # ESLint
 npm run test    # Vitest unit + integration tests
 npm run build   # Next.js production build
 ```
+
+## Git
+
+### Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) **without scopes**.
+
+Valid prefixes:
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `docs:` — documentation only changes
+- `style:` — code style changes (formatting, semicolons, etc.)
+- `refactor:` — code changes that don't change behavior
+- `perf:` — performance improvement
+- `test:` — adding or correcting tests
+- `build:` — build system or dependency changes
+- `ci:` — CI/CD configuration changes
+- `chore:` — maintenance, other changes
+
+Example: `feat: add user registration form`
+
+### Co-authorship
+
+Every commit must include `Co-Authored-By` trailer lines for:
+
+1. **The coding agent** — e.g. `Co-Authored-By: OpenCode <noreply@opencode.ai>`
+2. **The LLM model used** — e.g. `Co-Authored-By: Qwen 3.6 27B <noreply@opencode.ai>`
+
+Use the actual agent name and model loaded in your session. Common agent
+names: `Claude Code`, `OpenCode`, `Codex`. Common model examples:
+`Claude Sonnet 4.6`, `Qwen 3.6 27B`, `GPT-4o`.
+
+Example commit message:
+
+```
+feat: add user registration form
+
+Co-Authored-By: OpenCode <noreply@opencode.ai>
+Co-Authored-By: Qwen 3.6 27B <noreply@qwen.ai>
+```
+
+### Workflow
+
+Pushing directly to `main` is discouraged and requires explicit user consent.
+
+Typical git flow:
+
+1. Create a branch
+2. Commit changes
+3. Push changes
+4. Create a pull request
+5. Merge PR if all checks pass
+
+### Commit granularity
+
+Avoid making commits that are too small. Especially `feat:` and `fix:` commits
+should be substantial enough to be meaningful in a changelog. Group related
+changes into a single commit rather than committing every minor edit. At the
+same time, keep changes sensibly sized — don't bundle unrelated work together.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,10 @@ npm run build   # Next.js production build
 
 ### Commit messages
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) **without scopes**.
+Use [Conventional Commits](https://www.conventionalcommits.org/) **without
+scopes**. The commit history feeds `release-please`, which generates the
+changelog and version bumps — non-conforming messages break the release
+pipeline.
 
 Valid prefixes:
 
@@ -56,33 +59,44 @@ Example: `feat: add user registration form`
 
 Every commit must include `Co-Authored-By` trailer lines for:
 
-1. **The coding agent** — e.g. `Co-Authored-By: OpenCode <noreply@opencode.ai>`
-2. **The LLM model used** — e.g. `Co-Authored-By: Qwen 3.6 27B <noreply@opencode.ai>`
+1. **The coding agent** — the tool driving the session (e.g. `Claude Code`,
+   `OpenCode`, `Codex`, `Aider`, `Cursor`)
+2. **The LLM model** — the actual model loaded in your session, with whatever
+   version identifier is current
 
-Use the actual agent name and model loaded in your session. Common agent
-names: `Claude Code`, `OpenCode`, `Codex`. Common model examples:
-`Claude Sonnet 4.6`, `Qwen 3.6 27B`, `GPT-4o`.
+Use a `noreply@` address from the relevant vendor (e.g. `noreply@anthropic.com`
+for Claude models, `noreply@openai.com` for GPT models, `noreply@qwen.ai` for
+Qwen models). When the agent and model come from the same vendor, both trailers
+can share the same domain.
 
 Example commit message:
 
 ```
 feat: add user registration form
 
-Co-Authored-By: OpenCode <noreply@opencode.ai>
-Co-Authored-By: Qwen 3.6 27B <noreply@qwen.ai>
+Co-Authored-By: Claude Code <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 ```
 
 ### Workflow
 
-Pushing directly to `main` is discouraged and requires explicit user consent.
+Pushing directly to `main` is prohibited unless the user explicitly authorises
+it for a specific commit.
 
-Typical git flow:
+Standard flow:
 
-1. Create a branch
-2. Commit changes
-3. Push changes
-4. Create a pull request
-5. Merge PR if all checks pass
+1. Create a branch named `<type>/<short-slug>`, where `<type>` matches a
+   Conventional Commits prefix (e.g. `feat/user-registration`,
+   `docs/add-git-instructions`).
+2. Commit changes.
+3. Push the branch.
+4. Open a PR against `main` with `gh pr create`. The PR title should follow
+   Conventional Commits too, since squash-merges use it as the commit message.
+5. Wait for CI (`format-check`, `lint`, `test`, `build`) to pass, then merge.
+
+If any check fails, fix the underlying issue and re-push. Do **not** bypass with
+`git commit --no-verify`, `gh pr merge --admin`, or by disabling the failing
+job.
 
 ### Commit granularity
 


### PR DESCRIPTION
## Summary

- Document Conventional Commits (no scopes) as the required commit message format, with the full list of valid prefixes.
- Require `Co-Authored-By` trailers naming both the coding agent and the LLM model on every commit.
- Spell out the branch-and-PR workflow: `<type>/<short-slug>` branch names, no direct pushes to `main`, PR title follows Conventional Commits, and CI (`format-check`, `lint`, `test`, `build`) must pass.
- Require explicit user approval before merging: the user reviews every PR and either merges it themselves or instructs the agent to merge — agents must not merge on their own even after CI is green.
- Add commit-granularity guidance so `feat:`/`fix:` commits are substantial enough for the release-please changelog without bundling unrelated work.

## Test plan

- [ ] Skim the updated `Git` section in `AGENTS.md` for accuracy and tone.
- [ ] Confirm the merge-approval rule matches the intended workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)