### PR TITLE
fix: make CommentsButton visible by correcting commentsLink indexing and upsert on refresh

### DIFF
--- a/src/lib/repository/feedRepository.ts
+++ b/src/lib/repository/feedRepository.ts
@@ -82,12 +82,31 @@ export const refreshFeed = async (feedId: number) => {
     feed.titleFilterExpressions,
   );
 
+  const existingLinks = new Set(
+    (
+      await prisma.article.findMany({
+        where: { feedId: feed.id, userId: feed.userId },
+        select: { link: true },
+      })
+    ).map((a) => a.link),
+  );
+
   const createArticlePromises = filteredFeedItems.map((item) =>
-    prisma.article.create({
-      data: {
+    prisma.article.upsert({
+      where: {
+        userId_feedId_link: {
+          userId: feed.userId,
+          feedId: feed.id,
+          link: item.link,
+        },
+      },
+      create: {
         ...item,
         feedId: feed.id,
         userId: feed.userId,
+      },
+      update: {
+        commentsLink: item.commentsLink,
       },
     }),
   );
@@ -96,7 +115,8 @@ export const refreshFeed = async (feedId: number) => {
   // TODO check whether articles that already exist have changed
   const createdArticles = createArticleResults
     .filter((result) => result.status === "fulfilled")
-    .map((result) => result.value);
+    .map((result) => result.value)
+    .filter((article) => !existingLinks.has(article.link));
 
   const processedArticles = createdArticles.map((article) =>
     processArticle(article),

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -86,16 +86,20 @@ export const scrapeFeed = async (feed: Feed) => {
     (m) => m[0],
   );
 
-  const commentsUrls = itemBlocks.map((block) => {
-    const match = block.match(/<comments>(.*?)<\/comments>/s);
-    return match ? match[1].trim() : null;
-  });
+  const commentsLinkByItemLink = new Map<string, string>();
+  for (const block of itemBlocks) {
+    const linkMatch = block.match(/<link>(.*?)<\/link>/s);
+    const commentsMatch = block.match(/<comments>(.*?)<\/comments>/s);
+    if (linkMatch && commentsMatch) {
+      commentsLinkByItemLink.set(linkMatch[1].trim(), commentsMatch[1].trim());
+    }
+  }
 
   const validFeedItems: Pick<
     Article,
     "title" | "link" | "description" | "publicationDate" | "commentsLink"
   >[] = [];
-  parsedFeed.items.forEach((item, index) => {
+  parsedFeed.items.forEach((item) => {
     if (!item.title || !item.link || !item.pubDate) {
       logger.error({ item }, "Invalid feed item.");
     } else {
@@ -104,7 +108,7 @@ export const scrapeFeed = async (feed: Feed) => {
         link: item.link,
         description: item.description ? item.description : null,
         publicationDate: new Date(item.pubDate),
-        commentsLink: commentsUrls[index] ?? null,
+        commentsLink: commentsLinkByItemLink.get(item.link) ?? null,
       });
     }
   });

--- a/tests/integration/feedRepository.test.ts
+++ b/tests/integration/feedRepository.test.ts
@@ -69,6 +69,27 @@ describe("feedRepository.refreshFeed", () => {
     );
   });
 
+  it("updates commentsLink on an existing article when the feed is refreshed", async () => {
+    const feed = await createFeed({ userId });
+    vi.mocked(scrapeFeed).mockResolvedValue([
+      feedItem("Article", "https://example.com/1"),
+    ]);
+    await refreshFeed(feed.id);
+
+    const withComments = {
+      ...feedItem("Article", "https://example.com/1"),
+      commentsLink: "https://example.com/1#comments",
+    };
+    vi.mocked(scrapeFeed).mockResolvedValue([withComments]);
+    await refreshFeed(feed.id);
+
+    const article = await prisma.article.findFirstOrThrow({
+      where: { feedId: feed.id },
+    });
+    expect(article.commentsLink).toBe("https://example.com/1#comments");
+    expect(await prisma.article.count({ where: { feedId: feed.id } })).toBe(1);
+  });
+
   it("does not create articles whose title matches a filter expression", async () => {
     const feed = await createFeed({ userId, titleFilterExpressions: "Sports" });
     vi.mocked(scrapeFeed).mockResolvedValue([

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -180,4 +180,40 @@ describe("scrapeFeed", () => {
     expect(items[0].commentsLink).toBeNull();
     vi.unstubAllGlobals();
   });
+
+  it("assigns commentsLink by link URL, not position, when an invalid item precedes a valid one", async () => {
+    const xml = `
+      <rss><channel>
+        <item>
+          <title>Bad Item (no pubDate)</title>
+          <link>https://example.com/bad</link>
+          <comments>https://example.com/bad#comments</comments>
+        </item>
+        <item>
+          <title>Good Item</title>
+          <link>https://example.com/good</link>
+          <comments>https://example.com/good#comments</comments>
+        </item>
+      </channel></rss>
+    `;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
+    // parseFeed skips the bad item (no pubDate) — only returns the good one
+    vi.mocked(parseFeed).mockReturnValue({
+      type: "rss2",
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Good Item", "https://example.com/good")],
+    } as ReturnType<typeof parseFeed>);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items).toHaveLength(1);
+    expect(items[0].commentsLink).toBe("https://example.com/good#comments");
+    vi.unstubAllGlobals();
+  });
 });


### PR DESCRIPTION
## Summary

- **Index misalignment in `scraper.ts`**: `commentsLink` was associated with parsed items by raw XML `<item>` array position. When `htmlparser2` skipped invalid items (missing title/link/pubDate), the indices shifted, assigning the wrong `commentsLink` to subsequent articles. Fixed by building a `Map<link, commentsLink>` keyed on the item URL so each item looks up its own comments URL regardless of ordering or skipped entries.

- **Existing articles never updated in `feedRepository.ts`**: `prisma.article.create` silently fails for articles already in the DB (caught via `allSettled`), so all existing articles kept `commentsLink = null` forever — causing `CommentsButton` to always return `null`. Fixed by switching to `upsert` keyed on `userId_feedId_link`, updating `commentsLink` on conflict. A pre-fetch of existing links filters them out of the "newly created" set so scraping and AI lead generation aren't re-triggered for already-processed articles.

## Test Plan

- [ ] New unit test: invalid item preceding a valid one gets the correct `commentsLink` (not the wrong one due to index shift)
- [ ] New integration test: `commentsLink` is updated on an existing article when the feed is refreshed with new data
- [ ] All 48 tests pass (`npm test`)
- [ ] Refresh a feed whose RSS items contain `<comments>` URLs and verify the Comments button appears on the article card