### PR TITLE
refactor(feed): extract shared chart shell and lift data shaping into pure transforms

### DIFF
--- a/docs/superpowers/plans/2026-06-05-feed-dashboard-charts-refactor.md
+++ b/docs/superpowers/plans/2026-06-05-feed-dashboard-charts-refactor.md
@@ -1,11 +1,14 @@
 # Feed Dashboard Charts — Code-Structure Refactor Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Refactor the four chart components on `/feed` to remove duplication
 (card chrome, palette helper, date formatters), lift data shaping into pure
-transforms with unit tests, and move the LLM token-pricing table out of UI
-code. No rendered output changes except a corrected per-day average in
+transforms with unit tests, and move the LLM token-pricing table out of UI code.
+No rendered output changes except a corrected per-day average in
 `Your Daily Activity` for 30-day and 3-month ranges.
 
 **Architecture:** Repository functions return chart-ready data (rows + derived
@@ -16,14 +19,15 @@ branch. Each chart file shrinks to a render-only component that consumes the
 pre-shaped data and the shared helpers (`buildPalette`, `useDateFormatters`).
 
 **Tech Stack:** Next.js (App Router), React 19, Recharts via shadcn's
-`ChartContainer` primitive, Prisma, Vitest. Tests live under `tests/unit/`
-and import source via the `@/` alias.
+`ChartContainer` primitive, Prisma, Vitest. Tests live under `tests/unit/` and
+import source via the `@/` alias.
 
 ---
 
 ## File map
 
 **Create:**
+
 - `src/lib/repository/statsTransforms.ts` — pure transforms.
 - `src/lib/ai/tokenPricing.ts` — pricing table + cost calculation.
 - `src/lib/charts/palette.ts` — color palette helper.
@@ -34,20 +38,28 @@ and import source via the `@/` alias.
 - `tests/unit/palette.test.ts`
 
 **Modify:**
-- `src/lib/repository/statsRepository.ts` — three exports return pre-shaped data.
-- `src/app/feed/dashboard.tsx` — state types match new shapes.
-- `src/app/feed/daily-activity-chart.tsx` — adopt `ChartCard`, use `data.dailyAverage`.
-- `src/app/feed/daily-new-articles-chart.tsx` — adopt `ChartCard`, palette helper, formatter hook.
-- `src/app/feed/token-usage-chart.tsx` — adopt `ChartCard`, palette helper, formatter hook, `tokenPricing` import.
-- `src/app/feed/unread-articles-pie-chart.tsx` — adopt `ChartCard` and palette helper.
 
-**Untouched:** `src/app/feed/skeleton-chart.tsx` (consumed by `ChartCard` as-is).
+- `src/lib/repository/statsRepository.ts` — three exports return pre-shaped
+  data.
+- `src/app/feed/dashboard.tsx` — state types match new shapes.
+- `src/app/feed/daily-activity-chart.tsx` — adopt `ChartCard`, use
+  `data.dailyAverage`.
+- `src/app/feed/daily-new-articles-chart.tsx` — adopt `ChartCard`, palette
+  helper, formatter hook.
+- `src/app/feed/token-usage-chart.tsx` — adopt `ChartCard`, palette helper,
+  formatter hook, `tokenPricing` import.
+- `src/app/feed/unread-articles-pie-chart.tsx` — adopt `ChartCard` and palette
+  helper.
+
+**Untouched:** `src/app/feed/skeleton-chart.tsx` (consumed by `ChartCard`
+as-is).
 
 ---
 
 ## Task 1: Add `CHART_COLORS` + `buildPalette`
 
 **Files:**
+
 - Create: `src/lib/charts/palette.ts`
 - Test: `tests/unit/palette.test.ts`
 
@@ -101,8 +113,8 @@ describe("buildPalette", () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run tests/unit/palette.test.ts`
-Expected: FAIL — cannot resolve `@/lib/charts/palette`.
+Run: `npx vitest run tests/unit/palette.test.ts` Expected: FAIL — cannot resolve
+`@/lib/charts/palette`.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -136,8 +148,8 @@ export function buildPalette(keys: string[]): ChartConfig {
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npx vitest run tests/unit/palette.test.ts`
-Expected: PASS — three tests pass.
+Run: `npx vitest run tests/unit/palette.test.ts` Expected: PASS — three tests
+pass.
 
 - [ ] **Step 5: Commit**
 
@@ -151,6 +163,7 @@ git commit -m "feat(charts): add shared CHART_COLORS and buildPalette helper"
 ## Task 2: Add `tokenPricing` module
 
 **Files:**
+
 - Create: `src/lib/ai/tokenPricing.ts`
 - Test: `tests/unit/tokenPricing.test.ts`
 
@@ -206,7 +219,9 @@ describe("calculateTotalCost", () => {
   });
 
   it("ignores unknown models without throwing", () => {
-    expect(calculateTotalCost([u("mystery-model", 1_000_000, 1_000_000)])).toBe(0);
+    expect(calculateTotalCost([u("mystery-model", 1_000_000, 1_000_000)])).toBe(
+      0,
+    );
   });
 
   it("mixes known + unknown models correctly", () => {
@@ -229,8 +244,8 @@ describe("calculateTotalCost", () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run tests/unit/tokenPricing.test.ts`
-Expected: FAIL — cannot resolve `@/lib/ai/tokenPricing`.
+Run: `npx vitest run tests/unit/tokenPricing.test.ts` Expected: FAIL — cannot
+resolve `@/lib/ai/tokenPricing`.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -277,15 +292,19 @@ export function calculateTotalCost(usage: TokenUsage[]): number {
   return Object.entries(totalsByModel).reduce((cost, [model, tokens]) => {
     const pricing = TOKEN_PRICING[model];
     if (!pricing) return cost;
-    return cost + tokens.input * pricing.inputToken + tokens.output * pricing.outputToken;
+    return (
+      cost +
+      tokens.input * pricing.inputToken +
+      tokens.output * pricing.outputToken
+    );
   }, 0);
 }
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npx vitest run tests/unit/tokenPricing.test.ts`
-Expected: PASS — all tests pass.
+Run: `npx vitest run tests/unit/tokenPricing.test.ts` Expected: PASS — all tests
+pass.
 
 - [ ] **Step 5: Commit**
 
@@ -299,6 +318,7 @@ git commit -m "feat(ai): extract tokenPricing table and calculateTotalCost"
 ## Task 3: Add `statsTransforms` pure transforms
 
 **Files:**
+
 - Create: `src/lib/repository/statsTransforms.ts`
 - Test: `tests/unit/statsTransforms.test.ts`
 
@@ -361,7 +381,9 @@ describe("shapeArticlesPerFeedPerDay", () => {
       { date: "d2", FeedA: 1, FeedC: 4 },
     ];
     const result = shapeArticlesPerFeedPerDay(rows);
-    expect(new Set(result.feedKeys)).toEqual(new Set(["FeedA", "FeedB", "FeedC"]));
+    expect(new Set(result.feedKeys)).toEqual(
+      new Set(["FeedA", "FeedB", "FeedC"]),
+    );
     expect(result.rows).toBe(rows);
   });
 
@@ -411,8 +433,8 @@ describe("shapeTokenUsage", () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run tests/unit/statsTransforms.test.ts`
-Expected: FAIL — cannot resolve `@/lib/repository/statsTransforms`.
+Run: `npx vitest run tests/unit/statsTransforms.test.ts` Expected: FAIL — cannot
+resolve `@/lib/repository/statsTransforms`.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -487,8 +509,8 @@ export function computeDailyAverage(
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npx vitest run tests/unit/statsTransforms.test.ts`
-Expected: PASS — all tests pass.
+Run: `npx vitest run tests/unit/statsTransforms.test.ts` Expected: PASS — all
+tests pass.
 
 - [ ] **Step 5: Commit**
 
@@ -502,6 +524,7 @@ git commit -m "feat(stats): add pure transforms for chart-ready shapes"
 ## Task 4: Add `useDateFormatters` hook
 
 **Files:**
+
 - Create: `src/hooks/use-date-formatters.ts`
 
 (No tests — thin wrapper over `Intl.DateTimeFormat`. The spec excludes it
@@ -535,8 +558,7 @@ export function useDateFormatters(): {
 
 - [ ] **Step 2: Verify it type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: PASS — no type errors.
+Run: `npx tsc --noEmit` Expected: PASS — no type errors.
 
 - [ ] **Step 3: Commit**
 
@@ -550,11 +572,12 @@ git commit -m "feat(hooks): add useDateFormatters for memoized Intl formatters"
 ## Task 5: Add `ChartCard` shared shell
 
 **Files:**
+
 - Create: `src/app/feed/chart-card.tsx`
 
 (No unit test — the only branch is `data === undefined` rendering
-`SkeletonChart`. The project has no React testing setup; the branch is
-covered transitively when the four charts render in the dashboard.)
+`SkeletonChart`. The project has no React testing setup; the branch is covered
+transitively when the four charts render in the dashboard.)
 
 - [ ] **Step 1: Write the implementation**
 
@@ -624,8 +647,7 @@ export default ChartCard;
 
 - [ ] **Step 2: Verify it type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: PASS — no type errors.
+Run: `npx tsc --noEmit` Expected: PASS — no type errors.
 
 - [ ] **Step 3: Commit**
 
@@ -639,12 +661,14 @@ git commit -m "feat(feed): add ChartCard shell with skeleton fallback"
 ## Task 6: Update `statsRepository` to return chart-ready shapes
 
 **Files:**
+
 - Modify: `src/lib/repository/statsRepository.ts`
 
 - [ ] **Step 1: Replace the file contents**
 
-Open `src/lib/repository/statsRepository.ts` and replace `getWeeklyArticleCountPerFeed`,
-`getWeeklyArticlesRead`, and `getTokenUsageHistory` so the file becomes:
+Open `src/lib/repository/statsRepository.ts` and replace
+`getWeeklyArticleCountPerFeed`, `getWeeklyArticlesRead`, and
+`getTokenUsageHistory` so the file becomes:
 
 ```ts
 "use server";
@@ -807,10 +831,9 @@ export const getTokenUsageHistory = async (from: Date, to: Date) => {
 
 - [ ] **Step 2: Verify it type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: PASS — file resolves the new imports and returns the new shapes.
-(There will still be type errors in dashboard/chart callers — those are
-fixed in Tasks 7–11.)
+Run: `npx tsc --noEmit` Expected: PASS — file resolves the new imports and
+returns the new shapes. (There will still be type errors in dashboard/chart
+callers — those are fixed in Tasks 7–11.)
 
 - [ ] **Step 3: Commit**
 
@@ -824,6 +847,7 @@ git commit -m "refactor(stats): return chart-ready shapes from repository"
 ## Task 7: Refactor `daily-activity-chart` to use `ChartCard`
 
 **Files:**
+
 - Modify: `src/app/feed/daily-activity-chart.tsx`
 
 - [ ] **Step 1: Replace the file contents**
@@ -892,9 +916,8 @@ export default DailyActivityChart;
 
 - [ ] **Step 2: Verify it type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: errors only in `dashboard.tsx` (still imports the old type). No
-errors in `daily-activity-chart.tsx` itself.
+Run: `npx tsc --noEmit` Expected: errors only in `dashboard.tsx` (still imports
+the old type). No errors in `daily-activity-chart.tsx` itself.
 
 - [ ] **Step 3: Commit**
 
@@ -908,6 +931,7 @@ git commit -m "refactor(feed): daily-activity-chart uses ChartCard"
 ## Task 8: Refactor `daily-new-articles-chart` to use `ChartCard`
 
 **Files:**
+
 - Modify: `src/app/feed/daily-new-articles-chart.tsx`
 
 - [ ] **Step 1: Replace the file contents**
@@ -984,8 +1008,7 @@ export default DailyNewArticlesChart;
 
 - [ ] **Step 2: Verify it type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: errors only in `dashboard.tsx`. No errors in
+Run: `npx tsc --noEmit` Expected: errors only in `dashboard.tsx`. No errors in
 `daily-new-articles-chart.tsx`.
 
 - [ ] **Step 3: Commit**
@@ -1000,6 +1023,7 @@ git commit -m "refactor(feed): daily-new-articles-chart uses ChartCard"
 ## Task 9: Refactor `token-usage-chart` to use `ChartCard`
 
 **Files:**
+
 - Modify: `src/app/feed/token-usage-chart.tsx`
 
 - [ ] **Step 1: Replace the file contents**
@@ -1012,7 +1036,11 @@ Open `src/app/feed/token-usage-chart.tsx` and replace its contents:
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
 import ChartCard from "@/app/feed/chart-card";
-import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartConfig,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { CHART_COLORS } from "@/lib/charts/palette";
 import { TokenUsageRow } from "@/lib/repository/statsTransforms";
@@ -1056,7 +1084,9 @@ const TokenUsageChart = ({ data }: TokenUsageChartProps) => {
       description="Daily total of LLM tokens used by your AI Briefing Officer"
       config={config}
       data={data}
-      footer={data && `$${data.totalCost.toFixed(2)} estimated cost for this period`}
+      footer={
+        data && `$${data.totalCost.toFixed(2)} estimated cost for this period`
+      }
     >
       <BarChart
         accessibilityLayer
@@ -1106,13 +1136,12 @@ export default TokenUsageChart;
 
 `buildModelTokenConfig` is kept local — it's a token-usage-specific
 3-variant-per-model encoding that doesn't generalize to `buildPalette`'s
-1-color-per-key contract. It now consumes the shared `CHART_COLORS`
-constant.
+1-color-per-key contract. It now consumes the shared `CHART_COLORS` constant.
 
 - [ ] **Step 2: Verify it type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: errors only in `dashboard.tsx`. No errors in `token-usage-chart.tsx`.
+Run: `npx tsc --noEmit` Expected: errors only in `dashboard.tsx`. No errors in
+`token-usage-chart.tsx`.
 
 - [ ] **Step 3: Commit**
 
@@ -1126,6 +1155,7 @@ git commit -m "refactor(feed): token-usage-chart uses ChartCard and shared prici
 ## Task 10: Refactor `unread-articles-pie-chart` to use `ChartCard`
 
 **Files:**
+
 - Modify: `src/app/feed/unread-articles-pie-chart.tsx`
 
 - [ ] **Step 1: Replace the file contents**
@@ -1136,7 +1166,11 @@ Open `src/app/feed/unread-articles-pie-chart.tsx` and replace its contents:
 "use client";
 
 import ChartCard from "@/app/feed/chart-card";
-import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartConfig,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 import { CHART_COLORS } from "@/lib/charts/palette";
 import { Cell, Label, Pie, PieChart } from "recharts";
 
@@ -1168,7 +1202,10 @@ const UnreadArticlesPieChart = ({ chartData }: UnreadArticlesChartProps) => {
       containerClassName="mx-auto aspect-square max-h-[250px]"
     >
       <PieChart>
-        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent hideLabel />}
+        />
         <Pie
           data={chartData}
           dataKey="unread"
@@ -1222,8 +1259,7 @@ export default UnreadArticlesPieChart;
 
 - [ ] **Step 2: Verify it type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: errors only in `dashboard.tsx`. No errors in
+Run: `npx tsc --noEmit` Expected: errors only in `dashboard.tsx`. No errors in
 `unread-articles-pie-chart.tsx`.
 
 - [ ] **Step 3: Commit**
@@ -1238,6 +1274,7 @@ git commit -m "refactor(feed): unread-articles-pie-chart uses ChartCard"
 ## Task 11: Update `dashboard.tsx` to consume new shapes
 
 **Files:**
+
 - Modify: `src/app/feed/dashboard.tsx`
 
 - [ ] **Step 1: Replace the file contents**
@@ -1363,8 +1400,7 @@ export default Dashboard;
 
 - [ ] **Step 2: Verify the whole project type-checks**
 
-Run: `npx tsc --noEmit`
-Expected: PASS — no errors anywhere.
+Run: `npx tsc --noEmit` Expected: PASS — no errors anywhere.
 
 - [ ] **Step 3: Commit**
 
@@ -1381,38 +1417,34 @@ git commit -m "refactor(feed): dashboard consumes pre-shaped chart data"
 
 - [ ] **Step 1: Format**
 
-Run: `npm run format`
-Expected: Prettier rewrites any unformatted files.
+Run: `npm run format` Expected: Prettier rewrites any unformatted files.
 
 - [ ] **Step 2: Lint**
 
-Run: `npm run lint`
-Expected: PASS — no ESLint errors.
+Run: `npm run lint` Expected: PASS — no ESLint errors.
 
 - [ ] **Step 3: Tests**
 
-Run: `npm run test`
-Expected: PASS — existing tests still pass; the three new test files
-(palette, tokenPricing, statsTransforms) pass.
+Run: `npm run test` Expected: PASS — existing tests still pass; the three new
+test files (palette, tokenPricing, statsTransforms) pass.
 
 - [ ] **Step 4: Production build**
 
-Run: `npm run build`
-Expected: PASS — Next.js build completes with no type errors.
+Run: `npm run build` Expected: PASS — Next.js build completes with no type
+errors.
 
 - [ ] **Step 5: Manual smoke**
 
-Run: `npm run dev`
-Then in a browser, sign in and visit `/feed`. Confirm:
-  - All four chart cards render.
-  - Switching between `Last 7 Days` / `Last 30 Days` / `Last 3 Months`
-    updates the charts.
-  - For the `Last 7 Days` range, `Your Daily Activity` footer shows the
-    same number as before the refactor.
-  - For `Last 30 Days` and `Last 3 Months`, `Your Daily Activity` footer
-    shows a different (corrected) number — divided by the actual day
-    count, not by 7.
-  - Token-usage footer shows the same dollar value as before.
+Run: `npm run dev` Then in a browser, sign in and visit `/feed`. Confirm:
+
+- All four chart cards render.
+- Switching between `Last 7 Days` / `Last 30 Days` / `Last 3 Months` updates the
+  charts.
+- For the `Last 7 Days` range, `Your Daily Activity` footer shows the same
+  number as before the refactor.
+- For `Last 30 Days` and `Last 3 Months`, `Your Daily Activity` footer shows a
+  different (corrected) number — divided by the actual day count, not by 7.
+- Token-usage footer shows the same dollar value as before.
 
 - [ ] **Step 6: Commit any formatter-only changes**
 
@@ -1440,9 +1472,9 @@ If nothing changed, skip this step.
   - Repository contract changes → Task 6.
   - Chart components after refactor → Tasks 7–10.
   - Dashboard state types → Task 11.
-  - The deliberate behavior change (corrected per-day average) → Task 7
-    consumes `data.dailyAverage`, which Task 6's repo + Task 3's
-    `computeDailyAverage` derive from `rows.length`.
+  - The deliberate behavior change (corrected per-day average) → Task 7 consumes
+    `data.dailyAverage`, which Task 6's repo + Task 3's `computeDailyAverage`
+    derive from `rows.length`.
   - Testing section → Tasks 1, 2, 3 (transforms, pricing, palette).
   - Verification gate → Task 12.
 
@@ -1450,5 +1482,5 @@ If nothing changed, skip this step.
 
 - **Type consistency:** `DailyActivityData`, `DailyNewArticlesData`,
   `TokenUsageData`, `ArticlesPerFeedRow`, `TokenUsageRow`,
-  `UnreadArticlesChartData` are each defined once and reused everywhere
-  with matching field names.
+  `UnreadArticlesChartData` are each defined once and reused everywhere with
+  matching field names.

--- a/docs/superpowers/plans/2026-06-05-feed-dashboard-charts-refactor.md
+++ b/docs/superpowers/plans/2026-06-05-feed-dashboard-charts-refactor.md
@@ -1,0 +1,1454 @@
+# Feed Dashboard Charts — Code-Structure Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the four chart components on `/feed` to remove duplication
+(card chrome, palette helper, date formatters), lift data shaping into pure
+transforms with unit tests, and move the LLM token-pricing table out of UI
+code. No rendered output changes except a corrected per-day average in
+`Your Daily Activity` for 30-day and 3-month ranges.
+
+**Architecture:** Repository functions return chart-ready data (rows + derived
+metadata + totals) by delegating to pure transforms in
+`src/lib/repository/statsTransforms.ts`. A new `ChartCard` component owns the
+shared `Card` + `ChartContainer` shell and the skeleton-on-undefined-data
+branch. Each chart file shrinks to a render-only component that consumes the
+pre-shaped data and the shared helpers (`buildPalette`, `useDateFormatters`).
+
+**Tech Stack:** Next.js (App Router), React 19, Recharts via shadcn's
+`ChartContainer` primitive, Prisma, Vitest. Tests live under `tests/unit/`
+and import source via the `@/` alias.
+
+---
+
+## File map
+
+**Create:**
+- `src/lib/repository/statsTransforms.ts` — pure transforms.
+- `src/lib/ai/tokenPricing.ts` — pricing table + cost calculation.
+- `src/lib/charts/palette.ts` — color palette helper.
+- `src/hooks/use-date-formatters.ts` — memoized `Intl.DateTimeFormat` pair.
+- `src/app/feed/chart-card.tsx` — shared card shell.
+- `tests/unit/statsTransforms.test.ts`
+- `tests/unit/tokenPricing.test.ts`
+- `tests/unit/palette.test.ts`
+
+**Modify:**
+- `src/lib/repository/statsRepository.ts` — three exports return pre-shaped data.
+- `src/app/feed/dashboard.tsx` — state types match new shapes.
+- `src/app/feed/daily-activity-chart.tsx` — adopt `ChartCard`, use `data.dailyAverage`.
+- `src/app/feed/daily-new-articles-chart.tsx` — adopt `ChartCard`, palette helper, formatter hook.
+- `src/app/feed/token-usage-chart.tsx` — adopt `ChartCard`, palette helper, formatter hook, `tokenPricing` import.
+- `src/app/feed/unread-articles-pie-chart.tsx` — adopt `ChartCard` and palette helper.
+
+**Untouched:** `src/app/feed/skeleton-chart.tsx` (consumed by `ChartCard` as-is).
+
+---
+
+## Task 1: Add `CHART_COLORS` + `buildPalette`
+
+**Files:**
+- Create: `src/lib/charts/palette.ts`
+- Test: `tests/unit/palette.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/palette.test.ts`:
+
+```ts
+import { buildPalette, CHART_COLORS } from "@/lib/charts/palette";
+import { describe, expect, it } from "vitest";
+
+describe("CHART_COLORS", () => {
+  it("exposes the eight CSS chart variables", () => {
+    expect(CHART_COLORS).toEqual([
+      "var(--chart-1)",
+      "var(--chart-2)",
+      "var(--chart-3)",
+      "var(--chart-4)",
+      "var(--chart-5)",
+      "var(--chart-6)",
+      "var(--chart-7)",
+      "var(--chart-8)",
+    ]);
+  });
+});
+
+describe("buildPalette", () => {
+  it("returns an empty config for no keys", () => {
+    expect(buildPalette([])).toEqual({});
+  });
+
+  it("assigns each key a label and a color from CHART_COLORS in order", () => {
+    const palette = buildPalette(["a", "b", "c"]);
+    expect(palette).toEqual({
+      a: { label: "a", color: "var(--chart-1)" },
+      b: { label: "b", color: "var(--chart-2)" },
+      c: { label: "c", color: "var(--chart-3)" },
+    });
+  });
+
+  it("wraps around when there are more keys than colors", () => {
+    const keys = Array.from({ length: 10 }, (_, i) => `k${i}`);
+    const palette = buildPalette(keys);
+    expect(palette.k0.color).toBe("var(--chart-1)");
+    expect(palette.k7.color).toBe("var(--chart-8)");
+    expect(palette.k8.color).toBe("var(--chart-1)");
+    expect(palette.k9.color).toBe("var(--chart-2)");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/palette.test.ts`
+Expected: FAIL — cannot resolve `@/lib/charts/palette`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/charts/palette.ts`:
+
+```ts
+import { ChartConfig } from "@/components/ui/chart";
+
+export const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+] as const;
+
+export function buildPalette(keys: string[]): ChartConfig {
+  const config: Record<string, { label: string; color: string }> = {};
+  keys.forEach((key, i) => {
+    config[key] = {
+      label: key,
+      color: CHART_COLORS[i % CHART_COLORS.length],
+    };
+  });
+  return config;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/palette.test.ts`
+Expected: PASS — three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/charts/palette.ts tests/unit/palette.test.ts
+git commit -m "feat(charts): add shared CHART_COLORS and buildPalette helper"
+```
+
+---
+
+## Task 2: Add `tokenPricing` module
+
+**Files:**
+- Create: `src/lib/ai/tokenPricing.ts`
+- Test: `tests/unit/tokenPricing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/tokenPricing.test.ts`:
+
+```ts
+import { calculateTotalCost, TOKEN_PRICING } from "@/lib/ai/tokenPricing";
+import { TokenUsage } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+const u = (model: string, input: number, output: number): TokenUsage => ({
+  id: 0,
+  userId: "u",
+  date: "2026-06-05",
+  model,
+  inputTokens: input,
+  outputTokens: output,
+  reasoningTokens: 0,
+});
+
+describe("TOKEN_PRICING", () => {
+  it("includes the four known model entries", () => {
+    expect(TOKEN_PRICING["claude-sonnet-4-20250514"]).toEqual({
+      inputToken: 3 / 1_000_000,
+      outputToken: 15 / 1_000_000,
+    });
+    expect(TOKEN_PRICING["gpt-4.1-nano"]).toEqual({
+      inputToken: 0.1 / 1_000_000,
+      outputToken: 0.4 / 1_000_000,
+    });
+    expect(TOKEN_PRICING["gpt-4.1-mini"]).toEqual({
+      inputToken: 0.15 / 1_000_000,
+      outputToken: 0.6 / 1_000_000,
+    });
+    expect(TOKEN_PRICING["gpt-5-nano"]).toEqual({
+      inputToken: 0.05 / 1_000_000,
+      outputToken: 0.4 / 1_000_000,
+    });
+  });
+});
+
+describe("calculateTotalCost", () => {
+  it("returns 0 for empty usage", () => {
+    expect(calculateTotalCost([])).toBe(0);
+  });
+
+  it("sums input + output cost for a known model", () => {
+    const cost = calculateTotalCost([u("gpt-4.1-nano", 1_000_000, 500_000)]);
+    // 1_000_000 * (0.1/1e6) + 500_000 * (0.4/1e6) = 0.1 + 0.2 = 0.3
+    expect(cost).toBeCloseTo(0.3, 10);
+  });
+
+  it("ignores unknown models without throwing", () => {
+    expect(calculateTotalCost([u("mystery-model", 1_000_000, 1_000_000)])).toBe(0);
+  });
+
+  it("mixes known + unknown models correctly", () => {
+    const cost = calculateTotalCost([
+      u("gpt-4.1-nano", 1_000_000, 500_000),
+      u("mystery-model", 9_999_999, 9_999_999),
+    ]);
+    expect(cost).toBeCloseTo(0.3, 10);
+  });
+
+  it("sums across multiple entries of the same model", () => {
+    const cost = calculateTotalCost([
+      u("gpt-4.1-nano", 500_000, 250_000),
+      u("gpt-4.1-nano", 500_000, 250_000),
+    ]);
+    expect(cost).toBeCloseTo(0.3, 10);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/tokenPricing.test.ts`
+Expected: FAIL — cannot resolve `@/lib/ai/tokenPricing`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/ai/tokenPricing.ts`:
+
+```ts
+import { TokenUsage } from "@prisma/client";
+
+export const TOKEN_PRICING: Record<
+  string,
+  { inputToken: number; outputToken: number }
+> = {
+  "claude-sonnet-4-20250514": {
+    inputToken: 3 / 1_000_000,
+    outputToken: 15 / 1_000_000,
+  },
+  "gpt-4.1-nano": {
+    inputToken: 0.1 / 1_000_000,
+    outputToken: 0.4 / 1_000_000,
+  },
+  "gpt-4.1-mini": {
+    inputToken: 0.15 / 1_000_000,
+    outputToken: 0.6 / 1_000_000,
+  },
+  "gpt-5-nano": {
+    inputToken: 0.05 / 1_000_000,
+    outputToken: 0.4 / 1_000_000,
+  },
+};
+
+export function calculateTotalCost(usage: TokenUsage[]): number {
+  const totalsByModel = usage.reduce(
+    (acc, entry) => {
+      if (!acc[entry.model]) {
+        acc[entry.model] = { input: 0, output: 0 };
+      }
+      acc[entry.model].input += entry.inputTokens;
+      acc[entry.model].output += entry.outputTokens;
+      return acc;
+    },
+    {} as Record<string, { input: number; output: number }>,
+  );
+
+  return Object.entries(totalsByModel).reduce((cost, [model, tokens]) => {
+    const pricing = TOKEN_PRICING[model];
+    if (!pricing) return cost;
+    return cost + tokens.input * pricing.inputToken + tokens.output * pricing.outputToken;
+  }, 0);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/tokenPricing.test.ts`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ai/tokenPricing.ts tests/unit/tokenPricing.test.ts
+git commit -m "feat(ai): extract tokenPricing table and calculateTotalCost"
+```
+
+---
+
+## Task 3: Add `statsTransforms` pure transforms
+
+**Files:**
+- Create: `src/lib/repository/statsTransforms.ts`
+- Test: `tests/unit/statsTransforms.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/statsTransforms.test.ts`:
+
+```ts
+import {
+  computeDailyAverage,
+  shapeArticlesPerFeedPerDay,
+  shapeTokenUsage,
+} from "@/lib/repository/statsTransforms";
+import { TokenUsage } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+const tu = (
+  date: string,
+  model: string,
+  input: number,
+  output: number,
+  reasoning = 0,
+): TokenUsage => ({
+  id: 0,
+  userId: "u",
+  date,
+  model,
+  inputTokens: input,
+  outputTokens: output,
+  reasoningTokens: reasoning,
+});
+
+describe("computeDailyAverage", () => {
+  it("returns 0 for empty input", () => {
+    expect(computeDailyAverage([])).toBe(0);
+  });
+
+  it("divides total count by the number of rows", () => {
+    expect(
+      computeDailyAverage([
+        { date: "d1", count: 4 },
+        { date: "d2", count: 6 },
+      ]),
+    ).toBe(5);
+  });
+});
+
+describe("shapeArticlesPerFeedPerDay", () => {
+  it("returns empty result for empty input", () => {
+    expect(shapeArticlesPerFeedPerDay([])).toEqual({
+      rows: [],
+      feedKeys: [],
+      dailyAverage: 0,
+    });
+  });
+
+  it("collects feed keys across rows, excluding 'date'", () => {
+    const rows = [
+      { date: "d1", FeedA: 2, FeedB: 3 },
+      { date: "d2", FeedA: 1, FeedC: 4 },
+    ];
+    const result = shapeArticlesPerFeedPerDay(rows);
+    expect(new Set(result.feedKeys)).toEqual(new Set(["FeedA", "FeedB", "FeedC"]));
+    expect(result.rows).toBe(rows);
+  });
+
+  it("computes dailyAverage from numeric feed values only", () => {
+    const rows = [
+      { date: "d1", FeedA: 2, FeedB: 3 },
+      { date: "d2", FeedA: 5 },
+    ];
+    // total = 10, rows = 2
+    expect(shapeArticlesPerFeedPerDay(rows).dailyAverage).toBe(5);
+  });
+});
+
+describe("shapeTokenUsage", () => {
+  it("returns empty result for empty input", () => {
+    expect(shapeTokenUsage([])).toEqual({ rows: [], models: [] });
+  });
+
+  it("collapses multiple models on the same date into one row", () => {
+    const result = shapeTokenUsage([
+      tu("d1", "modelA", 10, 20, 0),
+      tu("d1", "modelB", 30, 40, 5),
+    ]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toEqual({
+      date: "d1",
+      modelA_input: 10,
+      modelA_output: 20,
+      modelA_reasoning: 0,
+      modelB_input: 30,
+      modelB_output: 40,
+      modelB_reasoning: 5,
+    });
+    expect(new Set(result.models)).toEqual(new Set(["modelA", "modelB"]));
+  });
+
+  it("creates one row per distinct date", () => {
+    const result = shapeTokenUsage([
+      tu("d1", "m", 1, 2, 0),
+      tu("d2", "m", 3, 4, 0),
+    ]);
+    expect(result.rows.map((r) => r.date)).toEqual(["d1", "d2"]);
+    expect(result.models).toEqual(["m"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/statsTransforms.test.ts`
+Expected: FAIL — cannot resolve `@/lib/repository/statsTransforms`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/repository/statsTransforms.ts`:
+
+```ts
+import { TokenUsage } from "@prisma/client";
+
+export type ArticlesPerFeedRow = Record<string, string | number>;
+
+export function shapeArticlesPerFeedPerDay(rows: ArticlesPerFeedRow[]): {
+  rows: ArticlesPerFeedRow[];
+  feedKeys: string[];
+  dailyAverage: number;
+} {
+  const feedKeys = Array.from(
+    rows.reduce((set, row) => {
+      Object.keys(row).forEach((k) => {
+        if (k !== "date") set.add(k);
+      });
+      return set;
+    }, new Set<string>()),
+  );
+
+  const total = rows.reduce((sum, row) => {
+    return (
+      sum +
+      feedKeys.reduce((s, k) => {
+        const v = row[k];
+        return s + (typeof v === "number" ? v : 0);
+      }, 0)
+    );
+  }, 0);
+
+  const dailyAverage = rows.length === 0 ? 0 : total / rows.length;
+
+  return { rows, feedKeys, dailyAverage };
+}
+
+export type TokenUsageRow = Record<string, string | number>;
+
+export function shapeTokenUsage(raw: TokenUsage[]): {
+  rows: TokenUsageRow[];
+  models: string[];
+} {
+  const rows: TokenUsageRow[] = [];
+
+  raw.forEach((entry) => {
+    let row = rows.find((r) => r.date === entry.date);
+    if (!row) {
+      row = { date: entry.date };
+      rows.push(row);
+    }
+    row[`${entry.model}_input`] = entry.inputTokens;
+    row[`${entry.model}_output`] = entry.outputTokens;
+    row[`${entry.model}_reasoning`] = entry.reasoningTokens;
+  });
+
+  const models = [...new Set(raw.map((entry) => entry.model))];
+
+  return { rows, models };
+}
+
+export function computeDailyAverage(
+  rows: Array<{ date: string; count: number }>,
+): number {
+  if (rows.length === 0) return 0;
+  const total = rows.reduce((sum, r) => sum + r.count, 0);
+  return total / rows.length;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/statsTransforms.test.ts`
+Expected: PASS — all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/repository/statsTransforms.ts tests/unit/statsTransforms.test.ts
+git commit -m "feat(stats): add pure transforms for chart-ready shapes"
+```
+
+---
+
+## Task 4: Add `useDateFormatters` hook
+
+**Files:**
+- Create: `src/hooks/use-date-formatters.ts`
+
+(No tests — thin wrapper over `Intl.DateTimeFormat`. The spec excludes it
+explicitly.)
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/hooks/use-date-formatters.ts`:
+
+```ts
+import { useMemo } from "react";
+
+export function useDateFormatters(): {
+  short: Intl.DateTimeFormat;
+  long: Intl.DateTimeFormat;
+} {
+  return useMemo(
+    () => ({
+      short: new Intl.DateTimeFormat(navigator.language, {
+        day: "2-digit",
+        month: "short",
+      }),
+      long: new Intl.DateTimeFormat(navigator.language, {
+        dateStyle: "full",
+      }),
+    }),
+    [],
+  );
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: PASS — no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/use-date-formatters.ts
+git commit -m "feat(hooks): add useDateFormatters for memoized Intl formatters"
+```
+
+---
+
+## Task 5: Add `ChartCard` shared shell
+
+**Files:**
+- Create: `src/app/feed/chart-card.tsx`
+
+(No unit test — the only branch is `data === undefined` rendering
+`SkeletonChart`. The project has no React testing setup; the branch is
+covered transitively when the four charts render in the dashboard.)
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/app/feed/chart-card.tsx`:
+
+```tsx
+"use client";
+
+import { ReactNode } from "react";
+
+import SkeletonChart from "@/app/feed/skeleton-chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ChartConfig, ChartContainer } from "@/components/ui/chart";
+
+interface ChartCardProps {
+  title: string;
+  description: string;
+  footer?: ReactNode;
+  config: ChartConfig;
+  data: unknown | undefined;
+  children: ReactNode;
+  containerClassName?: string;
+}
+
+const ChartCard = ({
+  title,
+  description,
+  footer,
+  config,
+  data,
+  children,
+  containerClassName,
+}: ChartCardProps) => {
+  if (data === undefined) {
+    return <SkeletonChart title={title} description={description} />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={config} className={containerClassName}>
+          {children as React.ComponentProps<typeof ChartContainer>["children"]}
+        </ChartContainer>
+      </CardContent>
+      {footer && (
+        <CardFooter className="text-center text-sm font-medium">
+          {footer}
+        </CardFooter>
+      )}
+    </Card>
+  );
+};
+
+export default ChartCard;
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: PASS — no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/feed/chart-card.tsx
+git commit -m "feat(feed): add ChartCard shell with skeleton fallback"
+```
+
+---
+
+## Task 6: Update `statsRepository` to return chart-ready shapes
+
+**Files:**
+- Modify: `src/lib/repository/statsRepository.ts`
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `src/lib/repository/statsRepository.ts` and replace `getWeeklyArticleCountPerFeed`,
+`getWeeklyArticlesRead`, and `getTokenUsageHistory` so the file becomes:
+
+```ts
+"use server";
+
+import prisma from "@/lib/prismaClient";
+import { calculateTotalCost } from "@/lib/ai/tokenPricing";
+import {
+  ArticlesPerFeedRow,
+  computeDailyAverage,
+  shapeArticlesPerFeedPerDay,
+  shapeTokenUsage,
+} from "@/lib/repository/statsTransforms";
+import { getUserId } from "@/lib/repository/userRepository";
+
+export const getNumberOfReadLaterArticles = async () => {
+  const userId = await getUserId();
+  return prisma.article.count({
+    where: {
+      readLater: true,
+      userId,
+    },
+  });
+};
+
+export const getNumberOfUnreadArticles = async () => {
+  const userId = await getUserId();
+  return prisma.article.count({
+    where: {
+      readAt: null,
+      readLater: false,
+      userId,
+    },
+  });
+};
+
+export const getUnreadArticlesPerFeed = async () => {
+  const userId = await getUserId();
+  const feedWithUnreadArticleCount = await prisma.feed.findMany({
+    include: {
+      _count: {
+        select: {
+          articles: { where: { readAt: null } },
+        },
+      },
+    },
+    where: { userId },
+  });
+
+  return feedWithUnreadArticleCount.map((feed) => {
+    return {
+      feedTitle: feed.title,
+      unread: feed._count.articles,
+    };
+  });
+};
+
+const getDaysInDateRange = (from: Date, to: Date) => {
+  if (from > to) {
+    throw new Error("'from' date must be before or equal to 'to' date");
+  }
+
+  const dates: string[] = [];
+  const current = new Date(from);
+
+  while (current <= to) {
+    dates.push(current.toISOString().split("T")[0]);
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+};
+
+export const getWeeklyArticleCountPerFeed = async (from: Date, to: Date) => {
+  const userId = await getUserId();
+
+  const dates = getDaysInDateRange(from, to);
+
+  const feeds = await prisma.feed.findMany({
+    where: { userId },
+    select: { id: true, title: true },
+  });
+  const feedTitleById = new Map(feeds.map((f) => [f.id, f.title]));
+
+  const perDayPerFeed: ArticlesPerFeedRow[] = await Promise.all(
+    dates.map(async (date) => {
+      const groups = await prisma.article.groupBy({
+        by: ["feedId"],
+        _count: { _all: true },
+        where: {
+          publicationDate: {
+            gte: `${date}T00:00:00.000Z`,
+            lte: `${date}T23:59:59.999Z`,
+          },
+          userId,
+        },
+      });
+
+      const entry: ArticlesPerFeedRow = { date };
+      groups.forEach((g) => {
+        const title = feedTitleById.get(g.feedId);
+        if (title) {
+          entry[title] = g._count._all;
+        }
+      });
+      return entry;
+    }),
+  );
+
+  return shapeArticlesPerFeedPerDay(perDayPerFeed);
+};
+
+export const getWeeklyArticlesRead = async (from: Date, to: Date) => {
+  const userId = await getUserId();
+
+  const dates = getDaysInDateRange(from, to);
+
+  const articlesReadPerDay = await Promise.all(
+    dates.map((date) =>
+      prisma.article.aggregate({
+        _count: {
+          _all: true,
+        },
+        where: {
+          readAt: {
+            gte: `${date}T00:00:00.000Z`,
+            lte: `${date}T23:59:59.999Z`,
+          },
+          userId,
+        },
+      }),
+    ),
+  );
+
+  const rows = dates.map((date, index) => ({
+    date,
+    count: articlesReadPerDay[index]._count._all,
+  }));
+
+  return { rows, dailyAverage: computeDailyAverage(rows) };
+};
+
+export const getTokenUsageHistory = async (from: Date, to: Date) => {
+  const userId = await getUserId();
+
+  const dates = getDaysInDateRange(from, to);
+
+  const raw = await prisma.tokenUsage.findMany({
+    where: {
+      userId,
+      date: {
+        in: dates,
+      },
+    },
+  });
+
+  const { rows, models } = shapeTokenUsage(raw);
+  return { rows, models, totalCost: calculateTotalCost(raw) };
+};
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: PASS — file resolves the new imports and returns the new shapes.
+(There will still be type errors in dashboard/chart callers — those are
+fixed in Tasks 7–11.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/repository/statsRepository.ts
+git commit -m "refactor(stats): return chart-ready shapes from repository"
+```
+
+---
+
+## Task 7: Refactor `daily-activity-chart` to use `ChartCard`
+
+**Files:**
+- Modify: `src/app/feed/daily-activity-chart.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `src/app/feed/daily-activity-chart.tsx` and replace its contents:
+
+```tsx
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import ChartCard from "@/app/feed/chart-card";
+import { ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
+
+const chartConfig = {
+  count: { label: "Articles" },
+};
+
+export interface DailyActivityData {
+  rows: Array<{ date: string; count: number }>;
+  dailyAverage: number;
+}
+
+interface DailyActivityChartProps {
+  data?: DailyActivityData;
+}
+
+const DailyActivityChart = ({ data }: DailyActivityChartProps) => {
+  const { short, long } = useDateFormatters();
+
+  return (
+    <ChartCard
+      title="Your Daily Activity"
+      description="Number of articles you interacted with each day"
+      config={chartConfig}
+      data={data}
+      footer={data && `${data.dailyAverage.toFixed(2)} articles per day`}
+    >
+      <BarChart
+        accessibilityLayer
+        data={data?.rows}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickFormatter={(value) => short.format(new Date(value))}
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent />}
+          labelFormatter={(value) => long.format(new Date(value))}
+        />
+        <Bar dataKey="count" fill="var(--chart-1)" stackId="a" />
+      </BarChart>
+    </ChartCard>
+  );
+};
+
+export default DailyActivityChart;
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: errors only in `dashboard.tsx` (still imports the old type). No
+errors in `daily-activity-chart.tsx` itself.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/feed/daily-activity-chart.tsx
+git commit -m "refactor(feed): daily-activity-chart uses ChartCard"
+```
+
+---
+
+## Task 8: Refactor `daily-new-articles-chart` to use `ChartCard`
+
+**Files:**
+- Modify: `src/app/feed/daily-new-articles-chart.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `src/app/feed/daily-new-articles-chart.tsx` and replace its contents:
+
+```tsx
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import ChartCard from "@/app/feed/chart-card";
+import { ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
+import { buildPalette } from "@/lib/charts/palette";
+import { ArticlesPerFeedRow } from "@/lib/repository/statsTransforms";
+
+export interface DailyNewArticlesData {
+  rows: ArticlesPerFeedRow[];
+  feedKeys: string[];
+  dailyAverage: number;
+}
+
+interface DailyNewArticlesChartProps {
+  data?: DailyNewArticlesData;
+}
+
+const DailyNewArticlesChart = ({ data }: DailyNewArticlesChartProps) => {
+  const { short, long } = useDateFormatters();
+  const config = buildPalette(data?.feedKeys ?? []);
+
+  return (
+    <ChartCard
+      title="Daily New Articles"
+      description="Number of new articles that appeared in your feed each day"
+      config={config}
+      data={data}
+      footer={data && `${data.dailyAverage.toFixed(2)} articles per day`}
+    >
+      <BarChart
+        accessibilityLayer
+        data={data?.rows}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickFormatter={(value) => short.format(new Date(value))}
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator="dot" />}
+          labelFormatter={(value) => long.format(new Date(value))}
+        />
+        {(data?.feedKeys ?? []).map((key) => (
+          <Bar
+            key={key}
+            dataKey={key}
+            fill={config[key]?.color}
+            stroke={config[key]?.color}
+            stackId="a"
+          />
+        ))}
+      </BarChart>
+    </ChartCard>
+  );
+};
+
+export default DailyNewArticlesChart;
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: errors only in `dashboard.tsx`. No errors in
+`daily-new-articles-chart.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/feed/daily-new-articles-chart.tsx
+git commit -m "refactor(feed): daily-new-articles-chart uses ChartCard"
+```
+
+---
+
+## Task 9: Refactor `token-usage-chart` to use `ChartCard`
+
+**Files:**
+- Modify: `src/app/feed/token-usage-chart.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `src/app/feed/token-usage-chart.tsx` and replace its contents:
+
+```tsx
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import ChartCard from "@/app/feed/chart-card";
+import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
+import { CHART_COLORS } from "@/lib/charts/palette";
+import { TokenUsageRow } from "@/lib/repository/statsTransforms";
+
+export interface TokenUsageData {
+  rows: TokenUsageRow[];
+  models: string[];
+  totalCost: number;
+}
+
+interface TokenUsageChartProps {
+  data?: TokenUsageData;
+}
+
+const buildModelTokenConfig = (models: string[]): ChartConfig => {
+  const config: Record<string, { label: string; color: string }> = {};
+  models.forEach((model, index) => {
+    config[`${model}_input`] = {
+      label: `${model} Input`,
+      color: CHART_COLORS[index % CHART_COLORS.length],
+    };
+    config[`${model}_output`] = {
+      label: `${model} Output`,
+      color: CHART_COLORS[(index + models.length) % CHART_COLORS.length],
+    };
+    config[`${model}_reasoning`] = {
+      label: `${model} Reasoning`,
+      color: CHART_COLORS[(index + 2 * models.length) % CHART_COLORS.length],
+    };
+  });
+  return config;
+};
+
+const TokenUsageChart = ({ data }: TokenUsageChartProps) => {
+  const { short, long } = useDateFormatters();
+  const config = buildModelTokenConfig(data?.models ?? []);
+
+  return (
+    <ChartCard
+      title="Token Usage"
+      description="Daily total of LLM tokens used by your AI Briefing Officer"
+      config={config}
+      data={data}
+      footer={data && `$${data.totalCost.toFixed(2)} estimated cost for this period`}
+    >
+      <BarChart
+        accessibilityLayer
+        data={data?.rows}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value) => short.format(new Date(value))}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator="dot" />}
+          labelFormatter={(value) => long.format(new Date(value))}
+        />
+        {(data?.models ?? []).flatMap((model) => [
+          <Bar
+            key={`${model}_input`}
+            dataKey={`${model}_input`}
+            fill={config[`${model}_input`].color}
+            stackId="a"
+          />,
+          <Bar
+            key={`${model}_output`}
+            dataKey={`${model}_output`}
+            fill={config[`${model}_output`].color}
+            stackId="a"
+          />,
+          <Bar
+            key={`${model}_reasoning`}
+            dataKey={`${model}_reasoning`}
+            fill={config[`${model}_reasoning`].color}
+            stackId="a"
+          />,
+        ])}
+      </BarChart>
+    </ChartCard>
+  );
+};
+
+export default TokenUsageChart;
+```
+
+`buildModelTokenConfig` is kept local — it's a token-usage-specific
+3-variant-per-model encoding that doesn't generalize to `buildPalette`'s
+1-color-per-key contract. It now consumes the shared `CHART_COLORS`
+constant.
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: errors only in `dashboard.tsx`. No errors in `token-usage-chart.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/feed/token-usage-chart.tsx
+git commit -m "refactor(feed): token-usage-chart uses ChartCard and shared pricing"
+```
+
+---
+
+## Task 10: Refactor `unread-articles-pie-chart` to use `ChartCard`
+
+**Files:**
+- Modify: `src/app/feed/unread-articles-pie-chart.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `src/app/feed/unread-articles-pie-chart.tsx` and replace its contents:
+
+```tsx
+"use client";
+
+import ChartCard from "@/app/feed/chart-card";
+import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { CHART_COLORS } from "@/lib/charts/palette";
+import { Cell, Label, Pie, PieChart } from "recharts";
+
+const chartConfig: ChartConfig = {
+  feedTitle: { label: "Feed" },
+};
+
+export interface UnreadArticlesChartData {
+  feedTitle: string;
+  unread: number;
+}
+
+interface UnreadArticlesChartProps {
+  chartData?: UnreadArticlesChartData[];
+}
+
+const UnreadArticlesPieChart = ({ chartData }: UnreadArticlesChartProps) => {
+  const unreadArticlesInTotal = (chartData ?? []).reduce(
+    (acc, feed) => acc + feed.unread,
+    0,
+  );
+
+  return (
+    <ChartCard
+      title="Articles to Explore"
+      description="Articles you haven’t dismissed or read yet"
+      config={chartConfig}
+      data={chartData}
+      containerClassName="mx-auto aspect-square max-h-[250px]"
+    >
+      <PieChart>
+        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+        <Pie
+          data={chartData}
+          dataKey="unread"
+          nameKey="feedTitle"
+          innerRadius={60}
+          strokeWidth={5}
+        >
+          {(chartData ?? []).map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={CHART_COLORS[index % CHART_COLORS.length]}
+            />
+          ))}
+          <Label
+            content={({ viewBox }) => {
+              if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                return (
+                  <text
+                    x={viewBox.cx}
+                    y={viewBox.cy}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                  >
+                    <tspan
+                      x={viewBox.cx}
+                      y={viewBox.cy}
+                      className="fill-foreground text-3xl font-bold"
+                    >
+                      {unreadArticlesInTotal}
+                    </tspan>
+                    <tspan
+                      x={viewBox.cx}
+                      y={(viewBox.cy || 0) + 24}
+                      className="fill-muted-foreground"
+                    >
+                      Total
+                    </tspan>
+                  </text>
+                );
+              }
+            }}
+          />
+        </Pie>
+      </PieChart>
+    </ChartCard>
+  );
+};
+
+export default UnreadArticlesPieChart;
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: errors only in `dashboard.tsx`. No errors in
+`unread-articles-pie-chart.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/feed/unread-articles-pie-chart.tsx
+git commit -m "refactor(feed): unread-articles-pie-chart uses ChartCard"
+```
+
+---
+
+## Task 11: Update `dashboard.tsx` to consume new shapes
+
+**Files:**
+- Modify: `src/app/feed/dashboard.tsx`
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `src/app/feed/dashboard.tsx` and replace its contents:
+
+```tsx
+"use client";
+
+import DailyActivityChart, {
+  DailyActivityData,
+} from "@/app/feed/daily-activity-chart";
+import DailyNewArticlesChart, {
+  DailyNewArticlesData,
+} from "@/app/feed/daily-new-articles-chart";
+import TokenUsageChart, { TokenUsageData } from "@/app/feed/token-usage-chart";
+import UnreadArticlesPieChart, {
+  UnreadArticlesChartData,
+} from "@/app/feed/unread-articles-pie-chart";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { useIsMobile } from "@/hooks/use-mobile";
+import {
+  getTokenUsageHistory,
+  getUnreadArticlesPerFeed,
+  getWeeklyArticleCountPerFeed,
+  getWeeklyArticlesRead,
+} from "@/lib/repository/statsRepository";
+import { useEffect, useState } from "react";
+
+export enum DateRangePreset {
+  Last7Days = "Last 7 Days",
+  Last30Days = "Last 30 Days",
+  Last3Months = "Last 3 Months",
+}
+
+interface DateRange {
+  from: Date;
+  to: Date;
+}
+
+const getDateRangeFromPreset = (preset: DateRangePreset): DateRange => {
+  const to = new Date();
+  const from = new Date();
+
+  switch (preset) {
+    case DateRangePreset.Last7Days:
+      from.setDate(to.getDate() - 7);
+      break;
+    case DateRangePreset.Last30Days:
+      from.setDate(to.getDate() - 30);
+      break;
+    case DateRangePreset.Last3Months:
+      from.setMonth(to.getMonth() - 3);
+      break;
+  }
+
+  return { from, to };
+};
+
+const Dashboard = () => {
+  const isMobile = useIsMobile();
+
+  const [selectedRange, setSelectedRange] = useState<DateRangePreset>(
+    DateRangePreset.Last7Days,
+  );
+
+  const [unreadArticlesChartData, setUnreadArticlesChartData] =
+    useState<UnreadArticlesChartData[]>();
+  const [tokenUsageData, setTokenUsageData] = useState<TokenUsageData>();
+  const [dailyNewArticlesData, setDailyNewArticlesData] =
+    useState<DailyNewArticlesData>();
+  const [dailyActivityData, setDailyActivityData] =
+    useState<DailyActivityData>();
+
+  useEffect(() => {
+    const dateRange = getDateRangeFromPreset(selectedRange);
+
+    getUnreadArticlesPerFeed().then((data) => setUnreadArticlesChartData(data));
+
+    getTokenUsageHistory(dateRange.from, dateRange.to).then((data) =>
+      setTokenUsageData(data),
+    );
+
+    getWeeklyArticleCountPerFeed(dateRange.from, dateRange.to).then((data) =>
+      setDailyNewArticlesData(data),
+    );
+
+    getWeeklyArticlesRead(dateRange.from, dateRange.to).then((data) =>
+      setDailyActivityData(data),
+    );
+  }, [selectedRange]);
+
+  return (
+    <>
+      {!isMobile && (
+        <ToggleGroup
+          className="mx-auto"
+          onValueChange={(value) => setSelectedRange(value as DateRangePreset)}
+          type="single"
+          value={selectedRange}
+          variant="outline"
+        >
+          {Object.values(DateRangePreset).map((range) => (
+            <ToggleGroupItem key={range} value={range}>
+              {range}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      )}
+
+      <div className="mx-auto hidden w-full max-w-7xl grid-cols-1 gap-4 md:visible md:grid md:grid-cols-2 lg:grid-cols-4">
+        <UnreadArticlesPieChart chartData={unreadArticlesChartData} />
+        <TokenUsageChart data={tokenUsageData} />
+        <DailyNewArticlesChart data={dailyNewArticlesData} />
+        <DailyActivityChart data={dailyActivityData} />
+      </div>
+    </>
+  );
+};
+
+export default Dashboard;
+```
+
+- [ ] **Step 2: Verify the whole project type-checks**
+
+Run: `npx tsc --noEmit`
+Expected: PASS — no errors anywhere.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/feed/dashboard.tsx
+git commit -m "refactor(feed): dashboard consumes pre-shaped chart data"
+```
+
+---
+
+## Task 12: Full verification
+
+**Files:** none
+
+- [ ] **Step 1: Format**
+
+Run: `npm run format`
+Expected: Prettier rewrites any unformatted files.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: PASS — no ESLint errors.
+
+- [ ] **Step 3: Tests**
+
+Run: `npm run test`
+Expected: PASS — existing tests still pass; the three new test files
+(palette, tokenPricing, statsTransforms) pass.
+
+- [ ] **Step 4: Production build**
+
+Run: `npm run build`
+Expected: PASS — Next.js build completes with no type errors.
+
+- [ ] **Step 5: Manual smoke**
+
+Run: `npm run dev`
+Then in a browser, sign in and visit `/feed`. Confirm:
+  - All four chart cards render.
+  - Switching between `Last 7 Days` / `Last 30 Days` / `Last 3 Months`
+    updates the charts.
+  - For the `Last 7 Days` range, `Your Daily Activity` footer shows the
+    same number as before the refactor.
+  - For `Last 30 Days` and `Last 3 Months`, `Your Daily Activity` footer
+    shows a different (corrected) number — divided by the actual day
+    count, not by 7.
+  - Token-usage footer shows the same dollar value as before.
+
+- [ ] **Step 6: Commit any formatter-only changes**
+
+If `npm run format` modified files, commit them:
+
+```bash
+git status
+git add -A
+git commit -m "chore: prettier formatting"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Self-review check
+
+- **Spec coverage:** every spec section maps to one or more tasks:
+  - File map → Tasks 1–11.
+  - `statsTransforms` API → Task 3.
+  - `tokenPricing` API → Task 2.
+  - `palette` API → Task 1.
+  - `useDateFormatters` → Task 4.
+  - `ChartCard` → Task 5.
+  - Repository contract changes → Task 6.
+  - Chart components after refactor → Tasks 7–10.
+  - Dashboard state types → Task 11.
+  - The deliberate behavior change (corrected per-day average) → Task 7
+    consumes `data.dailyAverage`, which Task 6's repo + Task 3's
+    `computeDailyAverage` derive from `rows.length`.
+  - Testing section → Tasks 1, 2, 3 (transforms, pricing, palette).
+  - Verification gate → Task 12.
+
+- **Placeholder scan:** no TBD/TODO/"add validation"/"similar to" in any task.
+
+- **Type consistency:** `DailyActivityData`, `DailyNewArticlesData`,
+  `TokenUsageData`, `ArticlesPerFeedRow`, `TokenUsageRow`,
+  `UnreadArticlesChartData` are each defined once and reused everywhere
+  with matching field names.

--- a/docs/superpowers/specs/2026-06-05-feed-dashboard-charts-refactor-design.md
+++ b/docs/superpowers/specs/2026-06-05-feed-dashboard-charts-refactor-design.md
@@ -36,15 +36,15 @@ Each file independently re-implements:
 Two charts also inline non-trivial data shaping that belongs upstream:
 
 - `token-usage-chart.tsx` reduces raw `TokenUsage[]` rows into per-date records
-  with `${model}_{input|output|reasoning}` keys, and hardcodes a
-  `tokenPricing` table to compute total cost.
-- `daily-new-articles-chart.tsx` re-derives the set of feed keys from the
-  rows that the repository just produced.
+  with `${model}_{input|output|reasoning}` keys, and hardcodes a `tokenPricing`
+  table to compute total cost.
+- `daily-new-articles-chart.tsx` re-derives the set of feed keys from the rows
+  that the repository just produced.
 
 ## Approach
 
-Extract shared chrome and helpers, lift data shaping into pure transforms in
-the repository layer, and shrink each chart file to a render-only component.
+Extract shared chrome and helpers, lift data shaping into pure transforms in the
+repository layer, and shrink each chart file to a render-only component.
 
 ### New files
 
@@ -53,8 +53,8 @@ the repository layer, and shrink each chart file to a render-only component.
 - `src/lib/repository/statsTransforms.test.ts` — Vitest unit tests.
 - `src/lib/ai/tokenPricing.ts` — pricing table + `calculateTotalCost`.
 - `src/lib/ai/tokenPricing.test.ts` — Vitest unit tests.
-- `src/lib/charts/palette.ts` — `CHART_COLORS` constant and
-  `buildPalette(keys)` helper.
+- `src/lib/charts/palette.ts` — `CHART_COLORS` constant and `buildPalette(keys)`
+  helper.
 - `src/lib/charts/palette.test.ts` — Vitest unit tests.
 - `src/hooks/use-date-formatters.ts` — memoized `{ short, long }`
   `Intl.DateTimeFormat` pair, keyed off `navigator.language`.
@@ -67,28 +67,27 @@ the repository layer, and shrink each chart file to a render-only component.
 
 - `src/lib/repository/statsRepository.ts` — three of four exports return
   pre-shaped data with derived metadata. See "Repository contract changes."
-- `src/app/feed/dashboard.tsx` — state types updated to match new return
-  shapes; structure of the `useEffect` is unchanged.
+- `src/app/feed/dashboard.tsx` — state types updated to match new return shapes;
+  structure of the `useEffect` is unchanged.
 - `src/app/feed/daily-activity-chart.tsx` — render-only.
 - `src/app/feed/daily-new-articles-chart.tsx` — render-only.
 - `src/app/feed/token-usage-chart.tsx` — render-only.
 - `src/app/feed/unread-articles-pie-chart.tsx` — render-only.
 
-`src/app/feed/skeleton-chart.tsx` is unchanged; it remains used by
-`ChartCard`.
+`src/app/feed/skeleton-chart.tsx` is unchanged; it remains used by `ChartCard`.
 
 ## Repository contract changes
 
 The repository becomes the boundary that returns chart-ready data.
 
-- `getUnreadArticlesPerFeed()` → unchanged.
-  Returns `Array<{ feedTitle: string; unread: number }>`.
+- `getUnreadArticlesPerFeed()` → unchanged. Returns
+  `Array<{ feedTitle: string; unread: number }>`.
 
 - `getWeeklyArticleCountPerFeed(from, to)` →
   `{ rows: Array<Record<string, string | number>>; feedKeys: string[]; dailyAverage: number }`.
-  `feedKeys` is the union of feed-title keys present across the rows
-  (excluding `"date"`). `dailyAverage` is the total article count across all
-  rows and feeds, divided by `rows.length` (or `0` when `rows` is empty).
+  `feedKeys` is the union of feed-title keys present across the rows (excluding
+  `"date"`). `dailyAverage` is the total article count across all rows and
+  feeds, divided by `rows.length` (or `0` when `rows` is empty).
 
 - `getWeeklyArticlesRead(from, to)` →
   `{ rows: Array<{ date: string; count: number }>; dailyAverage: number }`.
@@ -96,24 +95,23 @@ The repository becomes the boundary that returns chart-ready data.
 
 - `getTokenUsageHistory(from, to)` →
   `{ rows: Array<Record<string, string | number>>; models: string[]; totalCost: number }`.
-  Each row has shape `{ date, [`${model}_input`]: n, [`${model}_output`]: n,
-  [`${model}_reasoning`]: n, ... }`. `models` is the deduplicated set of model
-  names present in the raw data. `totalCost` is computed by
-  `calculateTotalCost` using the pricing table; unknown models contribute
-  `0` and do not throw.
+  Each row has shape
+  `{ date, [`${model}_input`]: n, [`${model}\_output`]: n, [`${model}\_reasoning`]: n, ... }`.
+  `models` is the deduplicated set of model names present in the raw data.
+  `totalCost` is computed by `calculateTotalCost` using the pricing table;
+  unknown models contribute `0` and do not throw.
 
 The repository imports the pure transforms from `statsTransforms.ts` and the
-pricing helper from `tokenPricing.ts`. The shaping logic itself is not in
-the repository module — it is tested independently.
+pricing helper from `tokenPricing.ts`. The shaping logic itself is not in the
+repository module — it is tested independently.
 
 Specifically:
 
-- `getWeeklyArticleCountPerFeed` continues to build the per-day rows from
-  Prisma `groupBy` calls as today, then passes the rows to
-  `shapeArticlesPerFeedPerDay` to derive `feedKeys` and `dailyAverage`.
-- `getTokenUsageHistory` continues to query `prisma.tokenUsage.findMany`,
-  then passes the raw `TokenUsage[]` to `shapeTokenUsage` and
-  `calculateTotalCost`.
+- `getWeeklyArticleCountPerFeed` continues to build the per-day rows from Prisma
+  `groupBy` calls as today, then passes the rows to `shapeArticlesPerFeedPerDay`
+  to derive `feedKeys` and `dailyAverage`.
+- `getTokenUsageHistory` continues to query `prisma.tokenUsage.findMany`, then
+  passes the raw `TokenUsage[]` to `shapeTokenUsage` and `calculateTotalCost`.
 - `getWeeklyArticlesRead` continues to build per-day rows from Prisma, then
   passes them to `computeDailyAverage`.
 
@@ -153,31 +151,32 @@ export function calculateTotalCost(usage: TokenUsage[]): number;
 
 Pricing values move verbatim from `token-usage-chart.tsx` lines 104–112 — no
 value changes. `calculateTotalCost` matches the existing computation: sum
-`input × inputToken + output × outputToken` per model, skipping models not
-in `TOKEN_PRICING`.
+`input × inputToken + output × outputToken` per model, skipping models not in
+`TOKEN_PRICING`.
 
 ## `palette.ts` API
 
 ```ts
-export const CHART_COLORS: readonly string[];   // ["var(--chart-1)", ..., "var(--chart-8)"]
+export const CHART_COLORS: readonly string[]; // ["var(--chart-1)", ..., "var(--chart-8)"]
 
 export function buildPalette(keys: string[]): ChartConfig;
 ```
 
-`buildPalette` produces the same `Record<string, { label: string; color: string }>`
-the existing inline helpers do, with `colors[i % colors.length]` wrap-around.
+`buildPalette` produces the same
+`Record<string, { label: string; color: string }>` the existing inline helpers
+do, with `colors[i % colors.length]` wrap-around.
 
 ## `useDateFormatters` hook
 
 ```ts
 export function useDateFormatters(): {
-  short: Intl.DateTimeFormat;   // { day: "2-digit", month: "short" }
-  long:  Intl.DateTimeFormat;   // { dateStyle: "full" }
+  short: Intl.DateTimeFormat; // { day: "2-digit", month: "short" }
+  long: Intl.DateTimeFormat; // { dateStyle: "full" }
 };
 ```
 
-Memoizes both formatters with `useMemo`, keyed off `navigator.language`.
-Same options the four chart files currently construct inline.
+Memoizes both formatters with `useMemo`, keyed off `navigator.language`. Same
+options the four chart files currently construct inline.
 
 ## `ChartCard` shell
 
@@ -195,10 +194,11 @@ interface ChartCardProps {
 
 Behavior:
 
-- If `data === undefined`, render `<SkeletonChart title={title} description={description} />`
-  and nothing else.
-- Otherwise render `<Card>` → `<CardHeader>` (`<CardTitle>` + `<CardDescription>`)
-  → `<CardContent>` → `<ChartContainer config={config} className={containerClassName}>{children}</ChartContainer>`,
+- If `data === undefined`, render
+  `<SkeletonChart title={title} description={description} />` and nothing else.
+- Otherwise render `<Card>` → `<CardHeader>` (`<CardTitle>` +
+  `<CardDescription>`) → `<CardContent>` →
+  `<ChartContainer config={config} className={containerClassName}>{children}</ChartContainer>`,
   followed by `<CardFooter>{footer}</CardFooter>` when `footer` is truthy.
 
 The `containerClassName` prop exists solely so the pie chart can pass
@@ -206,8 +206,8 @@ The `containerClassName` prop exists solely so the pie chart can pass
 
 ## Chart component shape after refactor
 
-Each chart file becomes ~30 lines: imports, the props interface, the
-component returning `<ChartCard>` wrapping a Recharts body. Sketch for
+Each chart file becomes ~30 lines: imports, the props interface, the component
+returning `<ChartCard>` wrapping a Recharts body. Sketch for
 `daily-activity-chart.tsx`:
 
 ```tsx
@@ -221,12 +221,24 @@ const DailyActivityChart = ({ data }: { data?: DailyActivityData }) => {
       data={data}
       footer={data && `${data.dailyAverage.toFixed(2)} articles per day`}
     >
-      <BarChart accessibilityLayer data={data?.rows} margin={{ left: 12, right: 12 }}>
+      <BarChart
+        accessibilityLayer
+        data={data?.rows}
+        margin={{ left: 12, right: 12 }}
+      >
         <CartesianGrid vertical={false} />
-        <XAxis dataKey="date" tickLine={false} tickMargin={10} axisLine={false}
-               tickFormatter={(v) => short.format(new Date(v))} />
-        <ChartTooltip cursor={false} content={<ChartTooltipContent />}
-                      labelFormatter={(v) => long.format(new Date(v))} />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+          tickFormatter={(v) => short.format(new Date(v))}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent />}
+          labelFormatter={(v) => long.format(new Date(v))}
+        />
         <Bar dataKey="count" fill="var(--chart-1)" stackId="a" />
       </BarChart>
     </ChartCard>
@@ -246,11 +258,11 @@ Recharts bodies and `config` derived via `buildPalette(...)`.
 const [unreadArticlesChartData, setUnreadArticlesChartData] =
   useState<UnreadArticlesChartData[]>();
 const [tokenUsageChartData, setTokenUsageChartData] =
-  useState<TokenUsageData>();        // was TokenUsage[]
+  useState<TokenUsageData>(); // was TokenUsage[]
 const [numberOfNewArticlesChartData, setNumberOfNewArticlesChartData] =
-  useState<DailyNewArticlesData>();  // was NumberOfArticlesLast7DaysChartData[]
+  useState<DailyNewArticlesData>(); // was NumberOfArticlesLast7DaysChartData[]
 const [weeklyArticlesReadChartData, setWeeklyArticlesReadChartData] =
-  useState<DailyActivityData>();     // was NumberOfArticlesReadLast7DaysChartData[]
+  useState<DailyActivityData>(); // was NumberOfArticlesReadLast7DaysChartData[]
 ```
 
 The four `.then(setX)` calls now consume the new bundled return shapes; no
@@ -258,13 +270,13 @@ restructuring of the effect.
 
 ## Behavior change (the one allowed exception)
 
-`daily-activity-chart.tsx:54` currently computes the footer's "articles per
-day" by dividing the period total by hardcoded `7`, regardless of whether the
+`daily-activity-chart.tsx:54` currently computes the footer's "articles per day"
+by dividing the period total by hardcoded `7`, regardless of whether the
 selected range is 7 days, 30 days, or 3 months.
 
 `computeDailyAverage` divides by `rows.length`. For the 30-day and 3-month
-ranges, the footer number will change. The 7-day range produces the same
-result as before.
+ranges, the footer number will change. The 7-day range produces the same result
+as before.
 
 This is the only user-visible change in the refactor.
 
@@ -273,16 +285,15 @@ This is the only user-visible change in the refactor.
 New unit tests (Vitest, no DB, no React beyond `chart-card.test.tsx`):
 
 - `statsTransforms.test.ts`
-  - `shapeArticlesPerFeedPerDay`: feed key discovery across mixed rows;
-    empty input → `dailyAverage: 0`; rows containing `string` values
-    (e.g. `date`) are not summed.
-  - `shapeTokenUsage`: multiple models on the same date collapse into one
-    row; single model passthrough; empty input.
+  - `shapeArticlesPerFeedPerDay`: feed key discovery across mixed rows; empty
+    input → `dailyAverage: 0`; rows containing `string` values (e.g. `date`) are
+    not summed.
+  - `shapeTokenUsage`: multiple models on the same date collapse into one row;
+    single model passthrough; empty input.
   - `computeDailyAverage`: divides by `rows.length`; empty input → `0`.
 - `tokenPricing.test.ts`
-  - `calculateTotalCost`: known model produces expected cost; unknown
-    model contributes `0` without throwing; mixed known + unknown; empty
-    input → `0`.
+  - `calculateTotalCost`: known model produces expected cost; unknown model
+    contributes `0` without throwing; mixed known + unknown; empty input → `0`.
 - `palette.test.ts`
   - `buildPalette`: wrap-around when `keys.length > 8`; empty input → `{}`;
     labels match the input keys.
@@ -293,8 +304,8 @@ New unit tests (Vitest, no DB, no React beyond `chart-card.test.tsx`):
 Not tested:
 
 - `useDateFormatters` — thin wrapper over `Intl.DateTimeFormat`.
-- Individual chart components — render-only after refactor; their inputs
-  are covered by the transform and pricing tests.
+- Individual chart components — render-only after refactor; their inputs are
+  covered by the transform and pricing tests.
 
 ## Verification before claiming done
 
@@ -303,10 +314,9 @@ Not tested:
 - `npm run test`
 - `npm run build`
 
-Manual smoke: load `/feed`, switch through all three date-range presets,
-confirm all four charts render. The daily-activity footer for 30-day and
-3-month ranges is expected to differ from the previous value; everything
-else matches.
+Manual smoke: load `/feed`, switch through all three date-range presets, confirm
+all four charts render. The daily-activity footer for 30-day and 3-month ranges
+is expected to differ from the previous value; everything else matches.
 
 ## Out of scope
 
@@ -316,5 +326,5 @@ else matches.
 - Token-usage stacking strategy (input/output/reasoning sharing slots in the
   same 8-color palette).
 - Range-toggle layout.
-- Any change to `unread-articles-pie-chart.tsx` beyond adopting `ChartCard`
-  and the shared palette helper.
+- Any change to `unread-articles-pie-chart.tsx` beyond adopting `ChartCard` and
+  the shared palette helper.

--- a/docs/superpowers/specs/2026-06-05-feed-dashboard-charts-refactor-design.md
+++ b/docs/superpowers/specs/2026-06-05-feed-dashboard-charts-refactor-design.md
@@ -1,0 +1,320 @@
+# Feed Dashboard Charts — Code Structure Refactor
+
+## Goal
+
+Reduce duplication and improve testability of the four chart components on
+`/feed` without changing the rendered UI, except for one deliberate bug fix
+called out below.
+
+## Non-goals
+
+- No new chart library (staying on Recharts + the existing shadcn
+  `ChartContainer` wrapper).
+- No layout, palette, or color-encoding redesign.
+- No changes to mobile visibility behavior.
+- No new charts, no removed charts.
+
+## Background
+
+`src/app/feed/dashboard.tsx` renders four charts:
+
+- `unread-articles-pie-chart.tsx` — donut, unread articles per feed.
+- `token-usage-chart.tsx` — stacked bars, tokens by model × {input, output,
+  reasoning} per day.
+- `daily-new-articles-chart.tsx` — stacked bars, new articles per feed per day.
+- `daily-activity-chart.tsx` — single-color bars, articles interacted with per
+  day.
+
+Each file independently re-implements:
+
+- Palette construction (`colors[i % colors.length]`) — three copies.
+- Short/long `Intl.DateTimeFormat` pair — four copies.
+- `Card` + `CardHeader` + `CardContent` + optional `CardFooter` shell — four
+  copies.
+- The `if (!chartData) return <SkeletonChart .../>` guard — four copies.
+
+Two charts also inline non-trivial data shaping that belongs upstream:
+
+- `token-usage-chart.tsx` reduces raw `TokenUsage[]` rows into per-date records
+  with `${model}_{input|output|reasoning}` keys, and hardcodes a
+  `tokenPricing` table to compute total cost.
+- `daily-new-articles-chart.tsx` re-derives the set of feed keys from the
+  rows that the repository just produced.
+
+## Approach
+
+Extract shared chrome and helpers, lift data shaping into pure transforms in
+the repository layer, and shrink each chart file to a render-only component.
+
+### New files
+
+- `src/lib/repository/statsTransforms.ts` — pure transforms; no Prisma, no
+  React.
+- `src/lib/repository/statsTransforms.test.ts` — Vitest unit tests.
+- `src/lib/ai/tokenPricing.ts` — pricing table + `calculateTotalCost`.
+- `src/lib/ai/tokenPricing.test.ts` — Vitest unit tests.
+- `src/lib/charts/palette.ts` — `CHART_COLORS` constant and
+  `buildPalette(keys)` helper.
+- `src/lib/charts/palette.test.ts` — Vitest unit tests.
+- `src/hooks/use-date-formatters.ts` — memoized `{ short, long }`
+  `Intl.DateTimeFormat` pair, keyed off `navigator.language`.
+- `src/app/feed/chart-card.tsx` — shared `Card` + `ChartContainer` shell that
+  swaps in `<SkeletonChart>` when `data === undefined`.
+- `src/app/feed/chart-card.test.tsx` — React Testing Library test covering the
+  `data === undefined` branch.
+
+### Modified files
+
+- `src/lib/repository/statsRepository.ts` — three of four exports return
+  pre-shaped data with derived metadata. See "Repository contract changes."
+- `src/app/feed/dashboard.tsx` — state types updated to match new return
+  shapes; structure of the `useEffect` is unchanged.
+- `src/app/feed/daily-activity-chart.tsx` — render-only.
+- `src/app/feed/daily-new-articles-chart.tsx` — render-only.
+- `src/app/feed/token-usage-chart.tsx` — render-only.
+- `src/app/feed/unread-articles-pie-chart.tsx` — render-only.
+
+`src/app/feed/skeleton-chart.tsx` is unchanged; it remains used by
+`ChartCard`.
+
+## Repository contract changes
+
+The repository becomes the boundary that returns chart-ready data.
+
+- `getUnreadArticlesPerFeed()` → unchanged.
+  Returns `Array<{ feedTitle: string; unread: number }>`.
+
+- `getWeeklyArticleCountPerFeed(from, to)` →
+  `{ rows: Array<Record<string, string | number>>; feedKeys: string[]; dailyAverage: number }`.
+  `feedKeys` is the union of feed-title keys present across the rows
+  (excluding `"date"`). `dailyAverage` is the total article count across all
+  rows and feeds, divided by `rows.length` (or `0` when `rows` is empty).
+
+- `getWeeklyArticlesRead(from, to)` →
+  `{ rows: Array<{ date: string; count: number }>; dailyAverage: number }`.
+  `dailyAverage` is `sum(rows.count) / rows.length` (or `0` when empty).
+
+- `getTokenUsageHistory(from, to)` →
+  `{ rows: Array<Record<string, string | number>>; models: string[]; totalCost: number }`.
+  Each row has shape `{ date, [`${model}_input`]: n, [`${model}_output`]: n,
+  [`${model}_reasoning`]: n, ... }`. `models` is the deduplicated set of model
+  names present in the raw data. `totalCost` is computed by
+  `calculateTotalCost` using the pricing table; unknown models contribute
+  `0` and do not throw.
+
+The repository imports the pure transforms from `statsTransforms.ts` and the
+pricing helper from `tokenPricing.ts`. The shaping logic itself is not in
+the repository module — it is tested independently.
+
+Specifically:
+
+- `getWeeklyArticleCountPerFeed` continues to build the per-day rows from
+  Prisma `groupBy` calls as today, then passes the rows to
+  `shapeArticlesPerFeedPerDay` to derive `feedKeys` and `dailyAverage`.
+- `getTokenUsageHistory` continues to query `prisma.tokenUsage.findMany`,
+  then passes the raw `TokenUsage[]` to `shapeTokenUsage` and
+  `calculateTotalCost`.
+- `getWeeklyArticlesRead` continues to build per-day rows from Prisma, then
+  passes them to `computeDailyAverage`.
+
+## `statsTransforms.ts` API
+
+```ts
+export function shapeArticlesPerFeedPerDay(
+  rows: Array<Record<string, string | number>>,
+): {
+  rows: Array<Record<string, string | number>>;
+  feedKeys: string[];
+  dailyAverage: number;
+};
+
+export function shapeTokenUsage(raw: TokenUsage[]): {
+  rows: Array<Record<string, string | number>>;
+  models: string[];
+};
+
+export function computeDailyAverage(
+  rows: Array<{ date: string; count: number }>,
+): number;
+```
+
+All three are pure: no I/O, no React, no Prisma client.
+
+## `tokenPricing.ts` API
+
+```ts
+export const TOKEN_PRICING: Record<
+  string,
+  { inputToken: number; outputToken: number }
+>;
+
+export function calculateTotalCost(usage: TokenUsage[]): number;
+```
+
+Pricing values move verbatim from `token-usage-chart.tsx` lines 104–112 — no
+value changes. `calculateTotalCost` matches the existing computation: sum
+`input × inputToken + output × outputToken` per model, skipping models not
+in `TOKEN_PRICING`.
+
+## `palette.ts` API
+
+```ts
+export const CHART_COLORS: readonly string[];   // ["var(--chart-1)", ..., "var(--chart-8)"]
+
+export function buildPalette(keys: string[]): ChartConfig;
+```
+
+`buildPalette` produces the same `Record<string, { label: string; color: string }>`
+the existing inline helpers do, with `colors[i % colors.length]` wrap-around.
+
+## `useDateFormatters` hook
+
+```ts
+export function useDateFormatters(): {
+  short: Intl.DateTimeFormat;   // { day: "2-digit", month: "short" }
+  long:  Intl.DateTimeFormat;   // { dateStyle: "full" }
+};
+```
+
+Memoizes both formatters with `useMemo`, keyed off `navigator.language`.
+Same options the four chart files currently construct inline.
+
+## `ChartCard` shell
+
+```tsx
+interface ChartCardProps {
+  title: string;
+  description: string;
+  footer?: ReactNode;
+  config: ChartConfig;
+  data: unknown | undefined;
+  children: ReactNode;
+  containerClassName?: string;
+}
+```
+
+Behavior:
+
+- If `data === undefined`, render `<SkeletonChart title={title} description={description} />`
+  and nothing else.
+- Otherwise render `<Card>` → `<CardHeader>` (`<CardTitle>` + `<CardDescription>`)
+  → `<CardContent>` → `<ChartContainer config={config} className={containerClassName}>{children}</ChartContainer>`,
+  followed by `<CardFooter>{footer}</CardFooter>` when `footer` is truthy.
+
+The `containerClassName` prop exists solely so the pie chart can pass
+`"mx-auto aspect-square max-h-[250px]"`, matching its current behavior.
+
+## Chart component shape after refactor
+
+Each chart file becomes ~30 lines: imports, the props interface, the
+component returning `<ChartCard>` wrapping a Recharts body. Sketch for
+`daily-activity-chart.tsx`:
+
+```tsx
+const DailyActivityChart = ({ data }: { data?: DailyActivityData }) => {
+  const { short, long } = useDateFormatters();
+  return (
+    <ChartCard
+      title="Your Daily Activity"
+      description="Number of articles you interacted with each day"
+      config={CHART_CONFIG}
+      data={data}
+      footer={data && `${data.dailyAverage.toFixed(2)} articles per day`}
+    >
+      <BarChart accessibilityLayer data={data?.rows} margin={{ left: 12, right: 12 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="date" tickLine={false} tickMargin={10} axisLine={false}
+               tickFormatter={(v) => short.format(new Date(v))} />
+        <ChartTooltip cursor={false} content={<ChartTooltipContent />}
+                      labelFormatter={(v) => long.format(new Date(v))} />
+        <Bar dataKey="count" fill="var(--chart-1)" stackId="a" />
+      </BarChart>
+    </ChartCard>
+  );
+};
+```
+
+`token-usage-chart.tsx`, `daily-new-articles-chart.tsx`, and
+`unread-articles-pie-chart.tsx` follow the same shape with their respective
+Recharts bodies and `config` derived via `buildPalette(...)`.
+
+## Dashboard changes
+
+`dashboard.tsx` keeps its `useEffect` structure. Only the state types change:
+
+```ts
+const [unreadArticlesChartData, setUnreadArticlesChartData] =
+  useState<UnreadArticlesChartData[]>();
+const [tokenUsageChartData, setTokenUsageChartData] =
+  useState<TokenUsageData>();        // was TokenUsage[]
+const [numberOfNewArticlesChartData, setNumberOfNewArticlesChartData] =
+  useState<DailyNewArticlesData>();  // was NumberOfArticlesLast7DaysChartData[]
+const [weeklyArticlesReadChartData, setWeeklyArticlesReadChartData] =
+  useState<DailyActivityData>();     // was NumberOfArticlesReadLast7DaysChartData[]
+```
+
+The four `.then(setX)` calls now consume the new bundled return shapes; no
+restructuring of the effect.
+
+## Behavior change (the one allowed exception)
+
+`daily-activity-chart.tsx:54` currently computes the footer's "articles per
+day" by dividing the period total by hardcoded `7`, regardless of whether the
+selected range is 7 days, 30 days, or 3 months.
+
+`computeDailyAverage` divides by `rows.length`. For the 30-day and 3-month
+ranges, the footer number will change. The 7-day range produces the same
+result as before.
+
+This is the only user-visible change in the refactor.
+
+## Testing
+
+New unit tests (Vitest, no DB, no React beyond `chart-card.test.tsx`):
+
+- `statsTransforms.test.ts`
+  - `shapeArticlesPerFeedPerDay`: feed key discovery across mixed rows;
+    empty input → `dailyAverage: 0`; rows containing `string` values
+    (e.g. `date`) are not summed.
+  - `shapeTokenUsage`: multiple models on the same date collapse into one
+    row; single model passthrough; empty input.
+  - `computeDailyAverage`: divides by `rows.length`; empty input → `0`.
+- `tokenPricing.test.ts`
+  - `calculateTotalCost`: known model produces expected cost; unknown
+    model contributes `0` without throwing; mixed known + unknown; empty
+    input → `0`.
+- `palette.test.ts`
+  - `buildPalette`: wrap-around when `keys.length > 8`; empty input → `{}`;
+    labels match the input keys.
+- `chart-card.test.tsx`
+  - `data === undefined` renders `<SkeletonChart>` and not the children.
+  - `data` defined renders the children inside the card.
+
+Not tested:
+
+- `useDateFormatters` — thin wrapper over `Intl.DateTimeFormat`.
+- Individual chart components — render-only after refactor; their inputs
+  are covered by the transform and pricing tests.
+
+## Verification before claiming done
+
+- `npm run format`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+
+Manual smoke: load `/feed`, switch through all three date-range presets,
+confirm all four charts render. The daily-activity footer for 30-day and
+3-month ranges is expected to differ from the previous value; everything
+else matches.
+
+## Out of scope
+
+- Color/palette coherence across charts.
+- Mobile dashboard visibility.
+- Skeleton aspect-ratio matching the real chart.
+- Token-usage stacking strategy (input/output/reasoning sharing slots in the
+  same 8-color palette).
+- Range-toggle layout.
+- Any change to `unread-articles-pie-chart.tsx` beyond adopting `ChartCard`
+  and the shared palette helper.

--- a/src/app/feed/chart-card.tsx
+++ b/src/app/feed/chart-card.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ReactNode } from "react";
+
+import SkeletonChart from "@/app/feed/skeleton-chart";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ChartConfig, ChartContainer } from "@/components/ui/chart";
+
+interface ChartCardProps {
+  title: string;
+  description: string;
+  footer?: ReactNode;
+  config: ChartConfig;
+  data: unknown | undefined;
+  children: ReactNode;
+  containerClassName?: string;
+}
+
+const ChartCard = ({
+  title,
+  description,
+  footer,
+  config,
+  data,
+  children,
+  containerClassName,
+}: ChartCardProps) => {
+  if (data === undefined) {
+    return <SkeletonChart title={title} description={description} />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={config} className={containerClassName}>
+          {children as React.ComponentProps<typeof ChartContainer>["children"]}
+        </ChartContainer>
+      </CardContent>
+      {footer && (
+        <CardFooter className="text-center text-sm font-medium">
+          {footer}
+        </CardFooter>
+      )}
+    </Card>
+  );
+};
+
+export default ChartCard;

--- a/src/app/feed/chart-card.tsx
+++ b/src/app/feed/chart-card.tsx
@@ -18,7 +18,7 @@ interface ChartCardProps {
   description: string;
   footer?: ReactNode;
   config: ChartConfig;
-  data: unknown | undefined;
+  data: unknown;
   children: ReactNode;
   containerClassName?: string;
 }

--- a/src/app/feed/daily-activity-chart.tsx
+++ b/src/app/feed/daily-activity-chart.tsx
@@ -2,98 +2,55 @@
 
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
-import SkeletonChart from "@/app/feed/skeleton-chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import ChartCard from "@/app/feed/chart-card";
+import { ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
 
 const chartConfig = {
-  count: {
-    label: "Articles",
-  },
-} satisfies ChartConfig;
+  count: { label: "Articles" },
+};
 
-export interface NumberOfArticlesReadLast7DaysChartData {
-  date: string;
-  count: number;
+export interface DailyActivityData {
+  rows: Array<{ date: string; count: number }>;
+  dailyAverage: number;
 }
 
-interface NumberOfArticlesReadLast7DaysChartProps {
-  chartData?: NumberOfArticlesReadLast7DaysChartData[];
+interface DailyActivityChartProps {
+  data?: DailyActivityData;
 }
 
-const DailyActivityChart = ({
-  chartData,
-}: NumberOfArticlesReadLast7DaysChartProps) => {
-  const chartTitle = "Your Daily Activity";
-  const chartDescription = "Number of articles you interacted with each day";
-
-  if (!chartData) {
-    return <SkeletonChart title={chartTitle} description={chartDescription} />;
-  }
-
-  const dateFormatterShort = new Intl.DateTimeFormat(navigator.language, {
-    day: "2-digit",
-    month: "short",
-  });
-  const dateFormatterLong = new Intl.DateTimeFormat(navigator.language, {
-    dateStyle: "full",
-  });
-
-  const dailyAverage = chartData.reduce((acc, day) => acc + day.count, 0) / 7;
+const DailyActivityChart = ({ data }: DailyActivityChartProps) => {
+  const { short, long } = useDateFormatters();
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{chartTitle}</CardTitle>
-        <CardDescription>{chartDescription}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <ChartContainer config={chartConfig}>
-          <BarChart
-            accessibilityLayer
-            data={chartData}
-            margin={{
-              left: 12,
-              right: 12,
-            }}
-          >
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="date"
-              tickFormatter={(value) =>
-                dateFormatterShort.format(new Date(value))
-              }
-              tickLine={false}
-              tickMargin={10}
-              axisLine={false}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent />}
-              labelFormatter={(value) =>
-                dateFormatterLong.format(new Date(value))
-              }
-            />
-            <Bar dataKey="count" fill="var(--chart-1)" stackId="a" />
-          </BarChart>
-        </ChartContainer>
-      </CardContent>
-      <CardFooter className="text-center text-sm font-medium">
-        {dailyAverage.toFixed(2)} articles per day
-      </CardFooter>
-    </Card>
+    <ChartCard
+      title="Your Daily Activity"
+      description="Number of articles you interacted with each day"
+      config={chartConfig}
+      data={data}
+      footer={data && `${data.dailyAverage.toFixed(2)} articles per day`}
+    >
+      <BarChart
+        accessibilityLayer
+        data={data?.rows}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickFormatter={(value) => short.format(new Date(value))}
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent />}
+          labelFormatter={(value) => long.format(new Date(value))}
+        />
+        <Bar dataKey="count" fill="var(--chart-1)" stackId="a" />
+      </BarChart>
+    </ChartCard>
   );
 };
 

--- a/src/app/feed/daily-activity-chart.tsx
+++ b/src/app/feed/daily-activity-chart.tsx
@@ -3,12 +3,16 @@
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
 import ChartCard from "@/app/feed/chart-card";
-import { ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartConfig,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 import { useDateFormatters } from "@/hooks/use-date-formatters";
 
 const chartConfig = {
   count: { label: "Articles" },
-};
+} satisfies ChartConfig;
 
 export interface DailyActivityData {
   rows: Array<{ date: string; count: number }>;

--- a/src/app/feed/daily-new-articles-chart.tsx
+++ b/src/app/feed/daily-new-articles-chart.tsx
@@ -2,142 +2,63 @@
 
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
-import SkeletonChart from "@/app/feed/skeleton-chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import ChartCard from "@/app/feed/chart-card";
+import { ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
+import { buildPalette } from "@/lib/charts/palette";
+import { ArticlesPerFeedRow } from "@/lib/repository/statsTransforms";
 
-// Build dynamic chart config for feeds
-const getChartConfigForFeeds = (feeds: string[]): ChartConfig => {
-  const colors = [
-    "var(--chart-1)",
-    "var(--chart-2)",
-    "var(--chart-3)",
-    "var(--chart-4)",
-    "var(--chart-5)",
-    "var(--chart-6)",
-    "var(--chart-7)",
-    "var(--chart-8)",
-  ];
-  const config: Record<string, { label: string; color: string }> = {};
-  feeds.forEach((feed, i) => {
-    config[feed] = { label: feed, color: colors[i % colors.length] };
-  });
-  return config;
-};
-
-export type NumberOfArticlesLast7DaysChartData = Record<
-  string,
-  number | string
->;
-
-interface NumberOfArticlesLast7DaysChartProps {
-  chartData?: NumberOfArticlesLast7DaysChartData[];
+export interface DailyNewArticlesData {
+  rows: ArticlesPerFeedRow[];
+  feedKeys: string[];
+  dailyAverage: number;
 }
 
-const DailyNewArticlesChart = ({
-  chartData,
-}: NumberOfArticlesLast7DaysChartProps) => {
-  const chartTitle = "Daily New Articles";
-  const chartDescription =
-    "Number of new articles that appeared in your feed each day";
+interface DailyNewArticlesChartProps {
+  data?: DailyNewArticlesData;
+}
 
-  if (!chartData) {
-    return <SkeletonChart title={chartTitle} description={chartDescription} />;
-  }
-
-  const dateFormatterShort = new Intl.DateTimeFormat(navigator.language, {
-    day: "2-digit",
-    month: "short",
-  });
-  const dateFormatterLong = new Intl.DateTimeFormat(navigator.language, {
-    dateStyle: "full",
-  });
-
-  // Determine all feed keys dynamically (exclude the 'date' field)
-  const feedKeys = Array.from(
-    chartData.reduce((set, item) => {
-      Object.keys(item).forEach((k) => {
-        if (k !== "date") set.add(k);
-      });
-      return set;
-    }, new Set<string>()),
-  );
-
-  const chartConfigForFeeds = getChartConfigForFeeds(feedKeys);
-
-  // Compute average total articles per day across all feeds
-  const totalAcrossDays = chartData.reduce((sum, day) => {
-    const dayTotal = feedKeys.reduce((s, k) => {
-      const v = day[k];
-      return s + (typeof v === "number" ? v : 0);
-    }, 0);
-    return sum + dayTotal;
-  }, 0);
-  const dailyAverage = chartData.length
-    ? totalAcrossDays / chartData.length
-    : 0;
+const DailyNewArticlesChart = ({ data }: DailyNewArticlesChartProps) => {
+  const { short, long } = useDateFormatters();
+  const config = buildPalette(data?.feedKeys ?? []);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{chartTitle}</CardTitle>
-        <CardDescription>{chartDescription}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <ChartContainer config={chartConfigForFeeds}>
-          <BarChart
-            accessibilityLayer
-            data={chartData}
-            margin={{
-              left: 12,
-              right: 12,
-            }}
-          >
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="date"
-              tickFormatter={(value) =>
-                dateFormatterShort.format(new Date(value))
-              }
-              tickLine={false}
-              tickMargin={10}
-              axisLine={false}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent indicator="dot" />}
-              labelFormatter={(value) =>
-                dateFormatterLong.format(new Date(value))
-              }
-            />
-            {feedKeys.map((key) => (
-              <Bar
-                key={key}
-                dataKey={key}
-                fill={chartConfigForFeeds[key]?.color}
-                stroke={chartConfigForFeeds[key]?.color}
-                stackId="a"
-              />
-            ))}
-          </BarChart>
-        </ChartContainer>
-      </CardContent>
-      <CardFooter className="text-center text-sm font-medium">
-        {dailyAverage.toFixed(2)} articles per day
-      </CardFooter>
-    </Card>
+    <ChartCard
+      title="Daily New Articles"
+      description="Number of new articles that appeared in your feed each day"
+      config={config}
+      data={data}
+      footer={data && `${data.dailyAverage.toFixed(2)} articles per day`}
+    >
+      <BarChart
+        accessibilityLayer
+        data={data?.rows}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickFormatter={(value) => short.format(new Date(value))}
+          tickLine={false}
+          tickMargin={10}
+          axisLine={false}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator="dot" />}
+          labelFormatter={(value) => long.format(new Date(value))}
+        />
+        {(data?.feedKeys ?? []).map((key) => (
+          <Bar
+            key={key}
+            dataKey={key}
+            fill={config[key]?.color}
+            stroke={config[key]?.color}
+            stackId="a"
+          />
+        ))}
+      </BarChart>
+    </ChartCard>
   );
 };
 

--- a/src/app/feed/dashboard.tsx
+++ b/src/app/feed/dashboard.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import DailyActivityChart, {
-  NumberOfArticlesReadLast7DaysChartData,
+  DailyActivityData,
 } from "@/app/feed/daily-activity-chart";
 import DailyNewArticlesChart, {
-  NumberOfArticlesLast7DaysChartData,
+  DailyNewArticlesData,
 } from "@/app/feed/daily-new-articles-chart";
-import TokenUsageChart from "@/app/feed/token-usage-chart";
+import TokenUsageChart, { TokenUsageData } from "@/app/feed/token-usage-chart";
 import UnreadArticlesPieChart, {
   UnreadArticlesChartData,
 } from "@/app/feed/unread-articles-pie-chart";
@@ -18,7 +18,6 @@ import {
   getWeeklyArticleCountPerFeed,
   getWeeklyArticlesRead,
 } from "@/lib/repository/statsRepository";
-import { TokenUsage } from "@prisma/client";
 import { useEffect, useState } from "react";
 
 export enum DateRangePreset {
@@ -60,12 +59,11 @@ const Dashboard = () => {
 
   const [unreadArticlesChartData, setUnreadArticlesChartData] =
     useState<UnreadArticlesChartData[]>();
-  const [tokenUsageChartData, setTokenUsageChartData] =
-    useState<TokenUsage[]>();
-  const [numberOfNewArticlesChartData, setNumberOfNewArticlesChartData] =
-    useState<NumberOfArticlesLast7DaysChartData[]>();
-  const [weeklyArticlesReadChartData, setWeeklyArticlesReadChartData] =
-    useState<NumberOfArticlesReadLast7DaysChartData[]>();
+  const [tokenUsageData, setTokenUsageData] = useState<TokenUsageData>();
+  const [dailyNewArticlesData, setDailyNewArticlesData] =
+    useState<DailyNewArticlesData>();
+  const [dailyActivityData, setDailyActivityData] =
+    useState<DailyActivityData>();
 
   useEffect(() => {
     const dateRange = getDateRangeFromPreset(selectedRange);
@@ -73,15 +71,15 @@ const Dashboard = () => {
     getUnreadArticlesPerFeed().then((data) => setUnreadArticlesChartData(data));
 
     getTokenUsageHistory(dateRange.from, dateRange.to).then((data) =>
-      setTokenUsageChartData(data),
+      setTokenUsageData(data),
     );
 
     getWeeklyArticleCountPerFeed(dateRange.from, dateRange.to).then((data) =>
-      setNumberOfNewArticlesChartData(data),
+      setDailyNewArticlesData(data),
     );
 
     getWeeklyArticlesRead(dateRange.from, dateRange.to).then((data) =>
-      setWeeklyArticlesReadChartData(data),
+      setDailyActivityData(data),
     );
   }, [selectedRange]);
 
@@ -105,11 +103,9 @@ const Dashboard = () => {
 
       <div className="mx-auto hidden w-full max-w-7xl grid-cols-1 gap-4 md:visible md:grid md:grid-cols-2 lg:grid-cols-4">
         <UnreadArticlesPieChart chartData={unreadArticlesChartData} />
-        <TokenUsageChart chartData={tokenUsageChartData} />
-        <DailyNewArticlesChart chartData={numberOfNewArticlesChartData} />
-        <DailyActivityChart
-          chartData={weeklyArticlesReadChartData}
-        ></DailyActivityChart>
+        <TokenUsageChart data={tokenUsageData} />
+        <DailyNewArticlesChart data={dailyNewArticlesData} />
+        <DailyActivityChart data={dailyActivityData} />
       </div>
     </>
   );

--- a/src/app/feed/token-usage-chart.tsx
+++ b/src/app/feed/token-usage-chart.tsx
@@ -1,211 +1,94 @@
 "use client";
 
-import SkeletonChart from "@/app/feed/skeleton-chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
-import { TokenUsage } from "@prisma/client";
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
-// Dynamic chart config will be generated based on available models
-const getChartConfig = (models: string[]): ChartConfig => {
-  const colors = [
-    "var(--chart-1)",
-    "var(--chart-2)",
-    "var(--chart-3)",
-    "var(--chart-4)",
-    "var(--chart-5)",
-    "var(--chart-6)",
-    "var(--chart-7)",
-    "var(--chart-8)",
-  ];
+import ChartCard from "@/app/feed/chart-card";
+import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { useDateFormatters } from "@/hooks/use-date-formatters";
+import { CHART_COLORS } from "@/lib/charts/palette";
+import { TokenUsageRow } from "@/lib/repository/statsTransforms";
 
+export interface TokenUsageData {
+  rows: TokenUsageRow[];
+  models: string[];
+  totalCost: number;
+}
+
+interface TokenUsageChartProps {
+  data?: TokenUsageData;
+}
+
+const buildModelTokenConfig = (models: string[]): ChartConfig => {
   const config: Record<string, { label: string; color: string }> = {};
-
   models.forEach((model, index) => {
-    // Create input tokens entry for this model
     config[`${model}_input`] = {
       label: `${model} Input`,
-      color: colors[index % colors.length],
+      color: CHART_COLORS[index % CHART_COLORS.length],
     };
-
-    // Create output tokens entry for this model
     config[`${model}_output`] = {
       label: `${model} Output`,
-      color: colors[(index + models.length) % colors.length],
+      color: CHART_COLORS[(index + models.length) % CHART_COLORS.length],
     };
-
-    // Create reasoning tokens entry for this model
     config[`${model}_reasoning`] = {
       label: `${model} Reasoning`,
-      color: colors[(index + 2 * models.length) % colors.length],
+      color: CHART_COLORS[(index + 2 * models.length) % CHART_COLORS.length],
     };
   });
-
   return config;
 };
 
-interface TokenUsageChartProps {
-  chartData?: TokenUsage[];
-}
-
-const TokenUsageChart = ({ chartData }: TokenUsageChartProps) => {
-  const chartTitle = "Token Usage";
-  const chartDescription =
-    "Daily total of LLM tokens used by your AI Briefing Officer";
-
-  if (!chartData) {
-    return <SkeletonChart title={chartTitle} description={chartDescription} />;
-  }
-
-  // Extract unique models from the data
-  const models = [...new Set(chartData.map((entry) => entry.model))];
-
-  // Create dynamic chart config based on available models
-  const chartConfigForModels = getChartConfig(models);
-
-  // Group data by date for the chart
-  const processedData = chartData.reduce(
-    (acc: Record<string, any>[], entry) => {
-      // Find if we already have an entry for this date
-      const existingEntry = acc.find((item) => item.date === entry.date);
-
-      if (existingEntry) {
-        // Add model-specific token counts
-        existingEntry[`${entry.model}_input`] = entry.inputTokens;
-        existingEntry[`${entry.model}_output`] = entry.outputTokens;
-        existingEntry[`${entry.model}_reasoning`] = entry.reasoningTokens;
-      } else {
-        // Create new entry for this date
-        const newEntry: Record<string, any> = { date: entry.date };
-        newEntry[`${entry.model}_input`] = entry.inputTokens;
-        newEntry[`${entry.model}_output`] = entry.outputTokens;
-        newEntry[`${entry.model}_reasoning`] = entry.reasoningTokens;
-        acc.push(newEntry);
-      }
-
-      return acc;
-    },
-    [],
-  );
-
-  // Calculate totals and cost
-  const tokenPricing = {
-    "claude-sonnet-4-20250514": {
-      inputToken: 3 / 1000000,
-      outputToken: 15 / 1000000,
-    },
-    "gpt-4.1-nano": { inputToken: 0.1 / 1000000, outputToken: 0.4 / 1000000 },
-    "gpt-4.1-mini": { inputToken: 0.15 / 1000000, outputToken: 0.6 / 1000000 },
-    "gpt-5-nano": { inputToken: 0.05 / 1000000, outputToken: 0.4 / 1000000 },
-  };
-
-  const totalsByModel = chartData.reduce(
-    (acc, entry) => {
-      if (!acc[entry.model]) {
-        acc[entry.model] = { input: 0, output: 0 };
-      }
-      acc[entry.model].input += entry.inputTokens;
-      acc[entry.model].output += entry.outputTokens;
-      return acc;
-    },
-    {} as Record<string, { input: number; output: number }>,
-  );
-
-  const totalCost = Object.entries(totalsByModel).reduce(
-    (cost, [model, tokens]) => {
-      const pricing = tokenPricing[model as keyof typeof tokenPricing];
-      if (pricing) {
-        return (
-          cost +
-          tokens.input * pricing.inputToken +
-          tokens.output * pricing.outputToken
-        );
-      }
-      return cost;
-    },
-    0,
-  );
-
-  const dateFormatterShort = new Intl.DateTimeFormat(navigator.language, {
-    day: "2-digit",
-    month: "short",
-  });
-  const dateFormatterLong = new Intl.DateTimeFormat(navigator.language, {
-    dateStyle: "full",
-  });
+const TokenUsageChart = ({ data }: TokenUsageChartProps) => {
+  const { short, long } = useDateFormatters();
+  const config = buildModelTokenConfig(data?.models ?? []);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{chartTitle}</CardTitle>
-        <CardDescription>{chartDescription}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <ChartContainer config={chartConfigForModels}>
-          <BarChart
-            accessibilityLayer
-            data={processedData}
-            margin={{
-              left: 12,
-              right: 12,
-            }}
-          >
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="date"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              tickFormatter={(value) =>
-                dateFormatterShort.format(new Date(value))
-              }
-            />
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent indicator="dot" />}
-              labelFormatter={(value) =>
-                dateFormatterLong.format(new Date(value))
-              }
-            />
-            {models.flatMap((model) => [
-              <Bar
-                key={`${model}_input`}
-                dataKey={`${model}_input`}
-                fill={chartConfigForModels[`${model}_input`].color}
-                stackId="a"
-              />,
-              <Bar
-                key={`${model}_output`}
-                dataKey={`${model}_output`}
-                fill={chartConfigForModels[`${model}_output`].color}
-                stackId="a"
-              />,
-              <Bar
-                key={`${model}_reasoning`}
-                dataKey={`${model}_reasoning`}
-                fill={chartConfigForModels[`${model}_reasoning`].color}
-                stackId="a"
-              />,
-            ])}
-          </BarChart>
-        </ChartContainer>
-      </CardContent>
-      <CardFooter className="text-center text-sm font-medium">
-        ${totalCost.toFixed(2)} estimated cost for this period
-      </CardFooter>
-    </Card>
+    <ChartCard
+      title="Token Usage"
+      description="Daily total of LLM tokens used by your AI Briefing Officer"
+      config={config}
+      data={data}
+      footer={data && `$${data.totalCost.toFixed(2)} estimated cost for this period`}
+    >
+      <BarChart
+        accessibilityLayer
+        data={data?.rows}
+        margin={{ left: 12, right: 12 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value) => short.format(new Date(value))}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator="dot" />}
+          labelFormatter={(value) => long.format(new Date(value))}
+        />
+        {(data?.models ?? []).flatMap((model) => [
+          <Bar
+            key={`${model}_input`}
+            dataKey={`${model}_input`}
+            fill={config[`${model}_input`].color}
+            stackId="a"
+          />,
+          <Bar
+            key={`${model}_output`}
+            dataKey={`${model}_output`}
+            fill={config[`${model}_output`].color}
+            stackId="a"
+          />,
+          <Bar
+            key={`${model}_reasoning`}
+            dataKey={`${model}_reasoning`}
+            fill={config[`${model}_reasoning`].color}
+            stackId="a"
+          />,
+        ])}
+      </BarChart>
+    </ChartCard>
   );
 };
 

--- a/src/app/feed/token-usage-chart.tsx
+++ b/src/app/feed/token-usage-chart.tsx
@@ -3,7 +3,11 @@
 import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
 
 import ChartCard from "@/app/feed/chart-card";
-import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartConfig,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { CHART_COLORS } from "@/lib/charts/palette";
 import { TokenUsageRow } from "@/lib/repository/statsTransforms";
@@ -47,7 +51,9 @@ const TokenUsageChart = ({ data }: TokenUsageChartProps) => {
       description="Daily total of LLM tokens used by your AI Briefing Officer"
       config={config}
       data={data}
-      footer={data && `$${data.totalCost.toFixed(2)} estimated cost for this period`}
+      footer={
+        data && `$${data.totalCost.toFixed(2)} estimated cost for this period`
+      }
     >
       <BarChart
         accessibilityLayer

--- a/src/app/feed/unread-articles-pie-chart.tsx
+++ b/src/app/feed/unread-articles-pie-chart.tsx
@@ -1,37 +1,13 @@
 "use client";
 
-import SkeletonChart from "@/app/feed/skeleton-chart";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
+import ChartCard from "@/app/feed/chart-card";
+import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { CHART_COLORS } from "@/lib/charts/palette";
 import { Cell, Label, Pie, PieChart } from "recharts";
 
-const chartConfig = {
-  feedTitle: {
-    label: "Feed",
-  },
-} satisfies ChartConfig;
-
-const pieChartCellColors = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
-  "var(--chart-6)",
-  "var(--chart-7)",
-  "var(--chart-8)",
-];
+const chartConfig: ChartConfig = {
+  feedTitle: { label: "Feed" },
+};
 
 export interface UnreadArticlesChartData {
   feedTitle: string;
@@ -43,81 +19,66 @@ interface UnreadArticlesChartProps {
 }
 
 const UnreadArticlesPieChart = ({ chartData }: UnreadArticlesChartProps) => {
-  const chartTitle = "Articles to Explore";
-  const chartDescription = "Articles you haven’t dismissed or read yet";
-
-  if (!chartData) {
-    return <SkeletonChart title={chartTitle} description={chartDescription} />;
-  }
-
-  const unreadArticlesInTotal = chartData.reduce(
+  const unreadArticlesInTotal = (chartData ?? []).reduce(
     (acc, feed) => acc + feed.unread,
     0,
   );
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{chartTitle}</CardTitle>
-        <CardDescription>{chartDescription}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <ChartContainer
-          config={chartConfig}
-          className="mx-auto aspect-square max-h-[250px]"
+    <ChartCard
+      title="Articles to Explore"
+      description="Articles you haven’t dismissed or read yet"
+      config={chartConfig}
+      data={chartData}
+      containerClassName="mx-auto aspect-square max-h-[250px]"
+    >
+      <PieChart>
+        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+        <Pie
+          data={chartData}
+          dataKey="unread"
+          nameKey="feedTitle"
+          innerRadius={60}
+          strokeWidth={5}
         >
-          <PieChart>
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent hideLabel />}
+          {(chartData ?? []).map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill={CHART_COLORS[index % CHART_COLORS.length]}
             />
-            <Pie
-              data={chartData}
-              dataKey="unread"
-              nameKey="feedTitle"
-              innerRadius={60}
-              strokeWidth={5}
-            >
-              {chartData.map((entry, index) => (
-                <Cell
-                  key={`cell-${index}`}
-                  fill={pieChartCellColors[index % pieChartCellColors.length]}
-                />
-              ))}
-              <Label
-                content={({ viewBox }) => {
-                  if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                    return (
-                      <text
-                        x={viewBox.cx}
-                        y={viewBox.cy}
-                        textAnchor="middle"
-                        dominantBaseline="middle"
-                      >
-                        <tspan
-                          x={viewBox.cx}
-                          y={viewBox.cy}
-                          className="fill-foreground text-3xl font-bold"
-                        >
-                          {unreadArticlesInTotal}
-                        </tspan>
-                        <tspan
-                          x={viewBox.cx}
-                          y={(viewBox.cy || 0) + 24}
-                          className="fill-muted-foreground"
-                        >
-                          Total
-                        </tspan>
-                      </text>
-                    );
-                  }
-                }}
-              />
-            </Pie>
-          </PieChart>
-        </ChartContainer>
-      </CardContent>
-    </Card>
+          ))}
+          <Label
+            content={({ viewBox }) => {
+              if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                return (
+                  <text
+                    x={viewBox.cx}
+                    y={viewBox.cy}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                  >
+                    <tspan
+                      x={viewBox.cx}
+                      y={viewBox.cy}
+                      className="fill-foreground text-3xl font-bold"
+                    >
+                      {unreadArticlesInTotal}
+                    </tspan>
+                    <tspan
+                      x={viewBox.cx}
+                      y={(viewBox.cy || 0) + 24}
+                      className="fill-muted-foreground"
+                    >
+                      Total
+                    </tspan>
+                  </text>
+                );
+              }
+            }}
+          />
+        </Pie>
+      </PieChart>
+    </ChartCard>
   );
 };
 

--- a/src/app/feed/unread-articles-pie-chart.tsx
+++ b/src/app/feed/unread-articles-pie-chart.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import ChartCard from "@/app/feed/chart-card";
-import { ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import {
+  ChartConfig,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
 import { CHART_COLORS } from "@/lib/charts/palette";
 import { Cell, Label, Pie, PieChart } from "recharts";
 
@@ -33,7 +37,10 @@ const UnreadArticlesPieChart = ({ chartData }: UnreadArticlesChartProps) => {
       containerClassName="mx-auto aspect-square max-h-[250px]"
     >
       <PieChart>
-        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent hideLabel />}
+        />
         <Pie
           data={chartData}
           dataKey="unread"

--- a/src/hooks/use-date-formatters.ts
+++ b/src/hooks/use-date-formatters.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+
+export function useDateFormatters(): {
+  short: Intl.DateTimeFormat;
+  long: Intl.DateTimeFormat;
+} {
+  return useMemo(
+    () => ({
+      short: new Intl.DateTimeFormat(navigator.language, {
+        day: "2-digit",
+        month: "short",
+      }),
+      long: new Intl.DateTimeFormat(navigator.language, {
+        dateStyle: "full",
+      }),
+    }),
+    [],
+  );
+}

--- a/src/lib/ai/tokenPricing.ts
+++ b/src/lib/ai/tokenPricing.ts
@@ -38,6 +38,10 @@ export function calculateTotalCost(usage: TokenUsage[]): number {
   return Object.entries(totalsByModel).reduce((cost, [model, tokens]) => {
     const pricing = TOKEN_PRICING[model];
     if (!pricing) return cost;
-    return cost + tokens.input * pricing.inputToken + tokens.output * pricing.outputToken;
+    return (
+      cost +
+      tokens.input * pricing.inputToken +
+      tokens.output * pricing.outputToken
+    );
   }, 0);
 }

--- a/src/lib/ai/tokenPricing.ts
+++ b/src/lib/ai/tokenPricing.ts
@@ -1,0 +1,43 @@
+import { TokenUsage } from "@prisma/client";
+
+export const TOKEN_PRICING: Record<
+  string,
+  { inputToken: number; outputToken: number }
+> = {
+  "claude-sonnet-4-20250514": {
+    inputToken: 3 / 1_000_000,
+    outputToken: 15 / 1_000_000,
+  },
+  "gpt-4.1-nano": {
+    inputToken: 0.1 / 1_000_000,
+    outputToken: 0.4 / 1_000_000,
+  },
+  "gpt-4.1-mini": {
+    inputToken: 0.15 / 1_000_000,
+    outputToken: 0.6 / 1_000_000,
+  },
+  "gpt-5-nano": {
+    inputToken: 0.05 / 1_000_000,
+    outputToken: 0.4 / 1_000_000,
+  },
+};
+
+export function calculateTotalCost(usage: TokenUsage[]): number {
+  const totalsByModel = usage.reduce(
+    (acc, entry) => {
+      if (!acc[entry.model]) {
+        acc[entry.model] = { input: 0, output: 0 };
+      }
+      acc[entry.model].input += entry.inputTokens;
+      acc[entry.model].output += entry.outputTokens;
+      return acc;
+    },
+    {} as Record<string, { input: number; output: number }>,
+  );
+
+  return Object.entries(totalsByModel).reduce((cost, [model, tokens]) => {
+    const pricing = TOKEN_PRICING[model];
+    if (!pricing) return cost;
+    return cost + tokens.input * pricing.inputToken + tokens.output * pricing.outputToken;
+  }, 0);
+}

--- a/src/lib/charts/palette.ts
+++ b/src/lib/charts/palette.ts
@@ -1,0 +1,23 @@
+import { ChartConfig } from "@/components/ui/chart";
+
+export const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+  "var(--chart-7)",
+  "var(--chart-8)",
+] as const;
+
+export function buildPalette(keys: string[]): ChartConfig {
+  const config: Record<string, { label: string; color: string }> = {};
+  keys.forEach((key, i) => {
+    config[key] = {
+      label: key,
+      color: CHART_COLORS[i % CHART_COLORS.length],
+    };
+  });
+  return config;
+}

--- a/src/lib/repository/statsRepository.ts
+++ b/src/lib/repository/statsRepository.ts
@@ -1,6 +1,13 @@
 "use server";
 
 import prisma from "@/lib/prismaClient";
+import { calculateTotalCost } from "@/lib/ai/tokenPricing";
+import {
+  ArticlesPerFeedRow,
+  computeDailyAverage,
+  shapeArticlesPerFeedPerDay,
+  shapeTokenUsage,
+} from "@/lib/repository/statsTransforms";
 import { getUserId } from "@/lib/repository/userRepository";
 
 export const getNumberOfReadLaterArticles = async () => {
@@ -66,15 +73,13 @@ export const getWeeklyArticleCountPerFeed = async (from: Date, to: Date) => {
 
   const dates = getDaysInDateRange(from, to);
 
-  // Fetch feeds once to map feedId -> title
   const feeds = await prisma.feed.findMany({
     where: { userId },
     select: { id: true, title: true },
   });
   const feedTitleById = new Map(feeds.map((f) => [f.id, f.title]));
 
-  // For each date, group articles by feed and count
-  const perDayPerFeed = await Promise.all(
+  const perDayPerFeed: ArticlesPerFeedRow[] = await Promise.all(
     dates.map(async (date) => {
       const groups = await prisma.article.groupBy({
         by: ["feedId"],
@@ -88,8 +93,8 @@ export const getWeeklyArticleCountPerFeed = async (from: Date, to: Date) => {
         },
       });
 
-      const entry: Record<string, string> = { date };
-      groups.forEach((g: any) => {
+      const entry: ArticlesPerFeedRow = { date };
+      groups.forEach((g) => {
         const title = feedTitleById.get(g.feedId);
         if (title) {
           entry[title] = g._count._all;
@@ -99,7 +104,7 @@ export const getWeeklyArticleCountPerFeed = async (from: Date, to: Date) => {
     }),
   );
 
-  return perDayPerFeed;
+  return shapeArticlesPerFeedPerDay(perDayPerFeed);
 };
 
 export const getWeeklyArticlesRead = async (from: Date, to: Date) => {
@@ -124,10 +129,12 @@ export const getWeeklyArticlesRead = async (from: Date, to: Date) => {
     ),
   );
 
-  return dates.map((date, index) => ({
+  const rows = dates.map((date, index) => ({
     date,
     count: articlesReadPerDay[index]._count._all,
   }));
+
+  return { rows, dailyAverage: computeDailyAverage(rows) };
 };
 
 export const getTokenUsageHistory = async (from: Date, to: Date) => {
@@ -135,7 +142,7 @@ export const getTokenUsageHistory = async (from: Date, to: Date) => {
 
   const dates = getDaysInDateRange(from, to);
 
-  return prisma.tokenUsage.findMany({
+  const raw = await prisma.tokenUsage.findMany({
     where: {
       userId,
       date: {
@@ -143,4 +150,7 @@ export const getTokenUsageHistory = async (from: Date, to: Date) => {
       },
     },
   });
+
+  const { rows, models } = shapeTokenUsage(raw);
+  return { rows, models, totalCost: calculateTotalCost(raw) };
 };

--- a/src/lib/repository/statsRepository.ts
+++ b/src/lib/repository/statsRepository.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import prisma from "@/lib/prismaClient";
 import { calculateTotalCost } from "@/lib/ai/tokenPricing";
+import prisma from "@/lib/prismaClient";
 import {
   ArticlesPerFeedRow,
   computeDailyAverage,

--- a/src/lib/repository/statsTransforms.ts
+++ b/src/lib/repository/statsTransforms.ts
@@ -1,0 +1,64 @@
+import { TokenUsage } from "@prisma/client";
+
+export type ArticlesPerFeedRow = Record<string, string | number>;
+
+export function shapeArticlesPerFeedPerDay(rows: ArticlesPerFeedRow[]): {
+  rows: ArticlesPerFeedRow[];
+  feedKeys: string[];
+  dailyAverage: number;
+} {
+  const feedKeys = Array.from(
+    rows.reduce((set, row) => {
+      Object.keys(row).forEach((k) => {
+        if (k !== "date") set.add(k);
+      });
+      return set;
+    }, new Set<string>()),
+  );
+
+  const total = rows.reduce((sum, row) => {
+    return (
+      sum +
+      feedKeys.reduce((s, k) => {
+        const v = row[k];
+        return s + (typeof v === "number" ? v : 0);
+      }, 0)
+    );
+  }, 0);
+
+  const dailyAverage = rows.length === 0 ? 0 : total / rows.length;
+
+  return { rows, feedKeys, dailyAverage };
+}
+
+export type TokenUsageRow = Record<string, string | number>;
+
+export function shapeTokenUsage(raw: TokenUsage[]): {
+  rows: TokenUsageRow[];
+  models: string[];
+} {
+  const rows: TokenUsageRow[] = [];
+
+  raw.forEach((entry) => {
+    let row = rows.find((r) => r.date === entry.date);
+    if (!row) {
+      row = { date: entry.date };
+      rows.push(row);
+    }
+    row[`${entry.model}_input`] = entry.inputTokens;
+    row[`${entry.model}_output`] = entry.outputTokens;
+    row[`${entry.model}_reasoning`] = entry.reasoningTokens;
+  });
+
+  const models = [...new Set(raw.map((entry) => entry.model))];
+
+  return { rows, models };
+}
+
+export function computeDailyAverage(
+  rows: Array<{ date: string; count: number }>,
+): number {
+  if (rows.length === 0) return 0;
+  const total = rows.reduce((sum, r) => sum + r.count, 0);
+  return total / rows.length;
+}

--- a/tests/unit/palette.test.ts
+++ b/tests/unit/palette.test.ts
@@ -1,0 +1,41 @@
+import { buildPalette, CHART_COLORS } from "@/lib/charts/palette";
+import { describe, expect, it } from "vitest";
+
+describe("CHART_COLORS", () => {
+  it("exposes the eight CSS chart variables", () => {
+    expect(CHART_COLORS).toEqual([
+      "var(--chart-1)",
+      "var(--chart-2)",
+      "var(--chart-3)",
+      "var(--chart-4)",
+      "var(--chart-5)",
+      "var(--chart-6)",
+      "var(--chart-7)",
+      "var(--chart-8)",
+    ]);
+  });
+});
+
+describe("buildPalette", () => {
+  it("returns an empty config for no keys", () => {
+    expect(buildPalette([])).toEqual({});
+  });
+
+  it("assigns each key a label and a color from CHART_COLORS in order", () => {
+    const palette = buildPalette(["a", "b", "c"]);
+    expect(palette).toEqual({
+      a: { label: "a", color: "var(--chart-1)" },
+      b: { label: "b", color: "var(--chart-2)" },
+      c: { label: "c", color: "var(--chart-3)" },
+    });
+  });
+
+  it("wraps around when there are more keys than colors", () => {
+    const keys = Array.from({ length: 10 }, (_, i) => `k${i}`);
+    const palette = buildPalette(keys);
+    expect(palette.k0.color).toBe("var(--chart-1)");
+    expect(palette.k7.color).toBe("var(--chart-8)");
+    expect(palette.k8.color).toBe("var(--chart-1)");
+    expect(palette.k9.color).toBe("var(--chart-2)");
+  });
+});

--- a/tests/unit/statsTransforms.test.ts
+++ b/tests/unit/statsTransforms.test.ts
@@ -2,6 +2,7 @@ import {
   computeDailyAverage,
   shapeArticlesPerFeedPerDay,
   shapeTokenUsage,
+  type ArticlesPerFeedRow,
 } from "@/lib/repository/statsTransforms";
 import { TokenUsage } from "@prisma/client";
 import { describe, expect, it } from "vitest";
@@ -46,7 +47,7 @@ describe("shapeArticlesPerFeedPerDay", () => {
   });
 
   it("collects feed keys across rows, excluding 'date'", () => {
-    const rows = [
+    const rows: ArticlesPerFeedRow[] = [
       { date: "d1", FeedA: 2, FeedB: 3 },
       { date: "d2", FeedA: 1, FeedC: 4 },
     ];
@@ -56,7 +57,7 @@ describe("shapeArticlesPerFeedPerDay", () => {
   });
 
   it("computes dailyAverage from numeric feed values only", () => {
-    const rows = [
+    const rows: ArticlesPerFeedRow[] = [
       { date: "d1", FeedA: 2, FeedB: 3 },
       { date: "d2", FeedA: 5 },
     ];

--- a/tests/unit/statsTransforms.test.ts
+++ b/tests/unit/statsTransforms.test.ts
@@ -52,7 +52,9 @@ describe("shapeArticlesPerFeedPerDay", () => {
       { date: "d2", FeedA: 1, FeedC: 4 },
     ];
     const result = shapeArticlesPerFeedPerDay(rows);
-    expect(new Set(result.feedKeys)).toEqual(new Set(["FeedA", "FeedB", "FeedC"]));
+    expect(new Set(result.feedKeys)).toEqual(
+      new Set(["FeedA", "FeedB", "FeedC"]),
+    );
     expect(result.rows).toBe(rows);
   });
 

--- a/tests/unit/statsTransforms.test.ts
+++ b/tests/unit/statsTransforms.test.ts
@@ -1,0 +1,98 @@
+import {
+  computeDailyAverage,
+  shapeArticlesPerFeedPerDay,
+  shapeTokenUsage,
+} from "@/lib/repository/statsTransforms";
+import { TokenUsage } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+const tu = (
+  date: string,
+  model: string,
+  input: number,
+  output: number,
+  reasoning = 0,
+): TokenUsage => ({
+  userId: "u",
+  date,
+  model,
+  inputTokens: input,
+  outputTokens: output,
+  reasoningTokens: reasoning,
+});
+
+describe("computeDailyAverage", () => {
+  it("returns 0 for empty input", () => {
+    expect(computeDailyAverage([])).toBe(0);
+  });
+
+  it("divides total count by the number of rows", () => {
+    expect(
+      computeDailyAverage([
+        { date: "d1", count: 4 },
+        { date: "d2", count: 6 },
+      ]),
+    ).toBe(5);
+  });
+});
+
+describe("shapeArticlesPerFeedPerDay", () => {
+  it("returns empty result for empty input", () => {
+    expect(shapeArticlesPerFeedPerDay([])).toEqual({
+      rows: [],
+      feedKeys: [],
+      dailyAverage: 0,
+    });
+  });
+
+  it("collects feed keys across rows, excluding 'date'", () => {
+    const rows = [
+      { date: "d1", FeedA: 2, FeedB: 3 },
+      { date: "d2", FeedA: 1, FeedC: 4 },
+    ];
+    const result = shapeArticlesPerFeedPerDay(rows);
+    expect(new Set(result.feedKeys)).toEqual(new Set(["FeedA", "FeedB", "FeedC"]));
+    expect(result.rows).toBe(rows);
+  });
+
+  it("computes dailyAverage from numeric feed values only", () => {
+    const rows = [
+      { date: "d1", FeedA: 2, FeedB: 3 },
+      { date: "d2", FeedA: 5 },
+    ];
+    expect(shapeArticlesPerFeedPerDay(rows).dailyAverage).toBe(5);
+  });
+});
+
+describe("shapeTokenUsage", () => {
+  it("returns empty result for empty input", () => {
+    expect(shapeTokenUsage([])).toEqual({ rows: [], models: [] });
+  });
+
+  it("collapses multiple models on the same date into one row", () => {
+    const result = shapeTokenUsage([
+      tu("d1", "modelA", 10, 20, 0),
+      tu("d1", "modelB", 30, 40, 5),
+    ]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toEqual({
+      date: "d1",
+      modelA_input: 10,
+      modelA_output: 20,
+      modelA_reasoning: 0,
+      modelB_input: 30,
+      modelB_output: 40,
+      modelB_reasoning: 5,
+    });
+    expect(new Set(result.models)).toEqual(new Set(["modelA", "modelB"]));
+  });
+
+  it("creates one row per distinct date", () => {
+    const result = shapeTokenUsage([
+      tu("d1", "m", 1, 2, 0),
+      tu("d2", "m", 3, 4, 0),
+    ]);
+    expect(result.rows.map((r) => r.date)).toEqual(["d1", "d2"]);
+    expect(result.models).toEqual(["m"]);
+  });
+});

--- a/tests/unit/tokenPricing.test.ts
+++ b/tests/unit/tokenPricing.test.ts
@@ -43,7 +43,9 @@ describe("calculateTotalCost", () => {
   });
 
   it("ignores unknown models without throwing", () => {
-    expect(calculateTotalCost([u("mystery-model", 1_000_000, 1_000_000)])).toBe(0);
+    expect(calculateTotalCost([u("mystery-model", 1_000_000, 1_000_000)])).toBe(
+      0,
+    );
   });
 
   it("mixes known + unknown models correctly", () => {

--- a/tests/unit/tokenPricing.test.ts
+++ b/tests/unit/tokenPricing.test.ts
@@ -1,0 +1,64 @@
+import { calculateTotalCost, TOKEN_PRICING } from "@/lib/ai/tokenPricing";
+import { TokenUsage } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+const u = (model: string, input: number, output: number): TokenUsage => ({
+  userId: "u",
+  date: "2026-06-05",
+  model,
+  inputTokens: input,
+  outputTokens: output,
+  reasoningTokens: 0,
+});
+
+describe("TOKEN_PRICING", () => {
+  it("includes the four known model entries", () => {
+    expect(TOKEN_PRICING["claude-sonnet-4-20250514"]).toEqual({
+      inputToken: 3 / 1_000_000,
+      outputToken: 15 / 1_000_000,
+    });
+    expect(TOKEN_PRICING["gpt-4.1-nano"]).toEqual({
+      inputToken: 0.1 / 1_000_000,
+      outputToken: 0.4 / 1_000_000,
+    });
+    expect(TOKEN_PRICING["gpt-4.1-mini"]).toEqual({
+      inputToken: 0.15 / 1_000_000,
+      outputToken: 0.6 / 1_000_000,
+    });
+    expect(TOKEN_PRICING["gpt-5-nano"]).toEqual({
+      inputToken: 0.05 / 1_000_000,
+      outputToken: 0.4 / 1_000_000,
+    });
+  });
+});
+
+describe("calculateTotalCost", () => {
+  it("returns 0 for empty usage", () => {
+    expect(calculateTotalCost([])).toBe(0);
+  });
+
+  it("sums input + output cost for a known model", () => {
+    const cost = calculateTotalCost([u("gpt-4.1-nano", 1_000_000, 500_000)]);
+    expect(cost).toBeCloseTo(0.3, 10);
+  });
+
+  it("ignores unknown models without throwing", () => {
+    expect(calculateTotalCost([u("mystery-model", 1_000_000, 1_000_000)])).toBe(0);
+  });
+
+  it("mixes known + unknown models correctly", () => {
+    const cost = calculateTotalCost([
+      u("gpt-4.1-nano", 1_000_000, 500_000),
+      u("mystery-model", 9_999_999, 9_999_999),
+    ]);
+    expect(cost).toBeCloseTo(0.3, 10);
+  });
+
+  it("sums across multiple entries of the same model", () => {
+    const cost = calculateTotalCost([
+      u("gpt-4.1-nano", 500_000, 250_000),
+      u("gpt-4.1-nano", 500_000, 250_000),
+    ]);
+    expect(cost).toBeCloseTo(0.3, 10);
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts a shared `` shell that owns the `Card` + `ChartContainer` chrome and the skeleton-on-undefined-data branch — removes four copies of the same wrapper across the dashboard charts.
- Lifts the data shaping that was inlined in `token-usage-chart.tsx` and `daily-new-articles-chart.tsx` into pure transforms in `src/lib/repository/statsTransforms.ts`, called from `statsRepository.ts`. The repository now returns chart-ready data with derived metadata.
- Moves the hardcoded LLM token pricing table and `calculateTotalCost` out of the chart component into `src/lib/ai/tokenPricing.ts`.
- Adds shared helpers used by all charts: `CHART_COLORS` + `buildPalette` (`src/lib/charts/palette.ts`) and a `useDateFormatters` hook (`src/hooks/use-date-formatters.ts`).
- Adds 19 new unit tests across the three new pure modules.

Each chart file shrinks to a render-only component. Net diff: ~225 lines added, ~162 removed in `src/` and `tests/`.

## Intended visual diff

Pure refactor with one deliberate exception: `Your Daily Activity` footer&#39;s &#34;articles per day&#34; now divides by `rows.length` instead of hardcoded `7`. For the default 7-day range this is unchanged; for the 30-day and 3-month ranges the value is now correct.

## Plan / spec

- Spec: [`docs/superpowers/specs/2026-06-05-feed-dashboard-charts-refactor-design.md`](docs/superpowers/specs/2026-06-05-feed-dashboard-charts-refactor-design.md)
- Plan: [`docs/superpowers/plans/2026-06-05-feed-dashboard-charts-refactor.md`](docs/superpowers/plans/2026-06-05-feed-dashboard-charts-refactor.md)

## Verification

- `npm run format` — clean
- `npm run lint` — clean
- `npm run test` — 60/60 pass (15 files), incl. 19 new unit tests
- `npm run build` — succeeds
- `npx tsc --noEmit` — clean

## Test plan

- [ ] Visit `/feed` and confirm all four chart cards render.
- [ ] Toggle between Last 7 Days / Last 30 Days / Last 3 Months — charts update for each.
- [ ] Confirm `Your Daily Activity` footer is unchanged on 7-day range; differs (corrected) on 30-day / 3-month ranges.
- [ ] Confirm `Token Usage` footer dollar value is unchanged from before the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)