### PR TITLE
refactor(ai): simplify summary prompt to key facts/takeaways only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# local database
+shadow.db

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,18 +1,10 @@
 export const systemPrompt =
-  "You are an expert at summarizing articles for professionals who want to quickly understand core content, key facts, and main arguments.";
+  "You are an expert at summarizing articles for professionals who want to quickly understand the key facts and takeaways.";
 
 export const buildSummaryPrompt = (textContent: string) =>
   `Write a summary in the following structure and **format your response in Markdown**:
 
-- Key Points (as a bullet list; use "Key Facts" for factual articles or "Key Takeaways" for opinion pieces)
-  Highlight one keywords or key term per bullet point in bold.
-- Executive Summary
-  Focus on a high information density while maintaining clear, readable language. Include all major points, arguments, or findings that are most relevant to understanding the article as a whole. Do not simply copy text verbatim — paraphrase and condense where appropriate.
-  Use paragraphs with headings to logically organize the information and emphasize key points. For major sections, use level 4 headings (\`####\`). For subsections that provide additional detail or clarification, use level 5 headings (\`#####\`). Feel free to include unstructured paragraphs when appropriate for smooth narrative flow.
-- Why the Full Article Is Worth Reading
-  Only include this section if the full article offers additional detail, nuance, or unique value that is not fully captured in your summary. If the summary sufficiently covers all key content, you may omit this section.
-
- Each should use a level 3 headings (\`###\`) with the respective content underneath:
+Use a level 3 heading (\`###\`) titled "Key Facts" for factual articles or "Key Takeaways" for opinion pieces, followed by a bullet list of 5–12 bullets. Highlight one keyword or key term per bullet point in bold.
 
 Below is the article:
 

--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -14,6 +14,7 @@ describe("buildSummaryPrompt", () => {
   it("includes the article text and Markdown structure cues", () => {
     const prompt = buildSummaryPrompt("Body text here");
     expect(prompt).toContain("Body text here");
-    expect(prompt).toContain("Executive Summary");
+    expect(prompt).toContain("Key Facts");
+    expect(prompt).toContain("Key Takeaways");
   });
 });


### PR DESCRIPTION
## Summary

- Remove Executive Summary and "Why the Full Article Is Worth Reading" sections — the summary now produces a single Key Facts / Key Takeaways bullet list
- Constrain bullet count to 5–12 items for consistent output length
- Align system prompt wording to match the simplified output format

## Test plan

- [ ] Generate a summary for a factual article and confirm a `### Key Facts` section with 5–12 bullets appears
- [ ] Generate a summary for an opinion piece and confirm `### Key Takeaways` is used instead
- [ ] Confirm no Executive Summary or "Worth Reading" section is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)