### PR TITLE
docs: clarify that feat/fix commit subjects should be user-facing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ Valid prefixes:
 - `ci:` — CI/CD configuration changes
 - `chore:` — maintenance, other changes
 
+`feat:` and `fix:` commits are included in the public changelog, so word the
+first line with end users in mind — describe what changed from their
+perspective, not how the code changed internally. The commit body may go into
+implementation details and technical context.
+
 Example: `feat: add user registration form`
 
 ### Co-authorship


### PR DESCRIPTION
## Summary

- Adds a note in `AGENTS.md` that `feat:` and `fix:` commits appear in the public changelog
- Instructs agents to write the commit subject line from the end user's perspective
- Notes that the commit body can contain implementation details and technical context