### PR TITLE
Align AI Summary page action buttons with ArticleCard design

### DIFF
--- a/docs/superpowers/plans/2026-06-17-ai-summary-page-action-alignment.md
+++ b/docs/superpowers/plans/2026-06-17-ai-summary-page-action-alignment.md
@@ -1,0 +1,338 @@
+# AI Summary Page Action Button Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the AI Summary page action button layout with ArticleCard by consolidating responsive layout and reading time into `ArticleCardActions`, moving the back button out of that component, and restructuring the AI Summary page layout.
+
+**Architecture:** The responsive two-row mobile layout currently duplicated in `ArticleCard`'s footer moves into `ArticleCardActions`, which gains an optional `readingTime` prop. `ArticleCard` simplifies its footer to a single `ArticleCardActions` call. The AI Summary page restructures its layout to show a standalone `BackButton` at the top and `ArticleCardActions` at the bottom after the summary content.
+
+**Tech Stack:** Next.js 15 App Router, React, TypeScript, Tailwind CSS, Prisma, `reading-time` npm package, shadcn/ui components
+
+## Global Constraints
+
+- No new dependencies
+- Follow existing Tailwind class patterns (see `article-card.tsx` for reference)
+- All TypeScript — no `any` types
+- `reading-time` package is already installed; import as `import readingTime from "reading-time"`
+- `ReadingTime` result type: `{ text: string; minutes: number; time: number; words: number }`
+
+---
+
+### Task 1: Refactor `ArticleCardActions` — remove back button, add responsive layout and `readingTime` prop
+
+**Files:**
+- Modify: `src/components/article/article-card-actions.tsx`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  interface ArticleCardActionsProps {
+    article: Prisma.ArticleGetPayload<{ include: { feed: true; scrape: true } }>;
+    hideSummarizeButton?: boolean;
+    readingTime?: { text: string; minutes: number; time: number; words: number };
+  }
+  ```
+
+- [ ] **Step 1: Replace the component**
+
+Replace the entire file content with:
+
+```tsx
+"use client";
+
+import AiSummaryButton from "@/components/article/ai-summary-button";
+import CommentsButton from "@/components/article/comments-button";
+import ToggleReadButton from "@/components/article/toggle-read-button";
+import ToggleReadLaterButton from "@/components/article/toggle-read-later-button";
+import ToggleStarredButton from "@/components/article/toggle-starred-button";
+import VisitButton from "@/components/article/visit-button";
+import { Prisma } from "@prisma/client";
+import { ClockIcon } from "lucide-react";
+
+interface ArticleCardActionsProps {
+  article: Prisma.ArticleGetPayload<{
+    include: { feed: true; scrape: true };
+  }>;
+  hideSummarizeButton?: boolean;
+  readingTime?: { text: string; minutes: number; time: number; words: number };
+}
+
+const ArticleCardActions = (props: ArticleCardActionsProps) => (
+  <>
+    {/* Mobile: row 1 — reading time left, icon buttons right */}
+    <div className="flex w-full items-center gap-2 md:hidden">
+      {props.readingTime && (
+        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+          <ClockIcon className="size-3" />
+          {props.readingTime.text}
+        </span>
+      )}
+      <div className="grow" />
+      <ToggleReadLaterButton article={props.article} variant="ghost" />
+      <ToggleStarredButton article={props.article} variant="ghost" />
+      <CommentsButton article={props.article} variant="ghost" />
+    </div>
+
+    {/* Mobile: row 2 — full-width labeled buttons */}
+    <div className="flex w-full gap-2 md:hidden">
+      <ToggleReadButton
+        article={props.article}
+        className="flex-1 justify-center text-sm"
+      />
+      {!props.hideSummarizeButton && (
+        <AiSummaryButton
+          feedId={props.article.feedId}
+          articleId={props.article.id}
+          className="flex-1 justify-center text-sm"
+        />
+      )}
+      <VisitButton
+        article={props.article}
+        className="flex-1 justify-center text-sm"
+      />
+    </div>
+
+    {/* Desktop: single row */}
+    <div className="hidden md:flex md:w-full md:items-center md:gap-2">
+      {props.readingTime && (
+        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+          <ClockIcon className="size-3" />
+          {props.readingTime.text}
+        </span>
+      )}
+      <div className="grow" />
+      <ToggleReadLaterButton article={props.article} />
+      <ToggleStarredButton article={props.article} />
+      <CommentsButton article={props.article} />
+      <ToggleReadButton
+        article={props.article}
+        className="cursor-pointer justify-start text-sm"
+      />
+      {!props.hideSummarizeButton && (
+        <AiSummaryButton
+          feedId={props.article.feedId}
+          articleId={props.article.id}
+          size="sm"
+          className="justify-start text-sm"
+        />
+      )}
+      <VisitButton
+        article={props.article}
+        size="sm"
+        className="justify-start text-sm"
+      />
+    </div>
+  </>
+);
+
+export default ArticleCardActions;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /home/marcus/Documents/Programming/briefing-officer
+npx tsc --noEmit
+```
+
+Expected: no errors (there will be type errors in `article-card.tsx` about the removed props — that's fine, they'll be fixed in Task 2).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/article/article-card-actions.tsx
+git commit -m "refactor: consolidate responsive layout and readingTime into ArticleCardActions, remove back button"
+```
+
+---
+
+### Task 2: Simplify `ArticleCard` footer
+
+**Files:**
+- Modify: `src/components/article/article-card.tsx`
+
+**Interfaces:**
+- Consumes: `ArticleCardActions` with props `{ article, readingTime? }`
+
+- [ ] **Step 1: Replace the CardFooter section**
+
+In `src/components/article/article-card.tsx`, replace the entire `<CardFooter>` block (lines 143–186) with:
+
+```tsx
+<CardFooter className="flex-col gap-3 border-t px-4 md:flex md:flex-row md:items-center md:gap-2 md:px-6">
+  <ArticleCardActions
+    article={props.article}
+    readingTime={articleReadingTime}
+  />
+</CardFooter>
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Start dev server and visually verify the card layout**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000/feed` in a browser. Check:
+- Desktop: single row with reading time left, all action buttons right
+- Mobile (resize to < 768px): two rows — row 1 icon buttons with reading time, row 2 full-width Dismiss/Summarize/Visit
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/article/article-card.tsx
+git commit -m "refactor: simplify ArticleCard footer to use ArticleCardActions"
+```
+
+---
+
+### Task 3: Restructure the AI Summary page
+
+**Files:**
+- Modify: `src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx`
+
+**Interfaces:**
+- Consumes: `ArticleCardActions` with props `{ article, hideSummarizeButton: true, readingTime? }`
+- Consumes: `BackButton` from `@/components/navigation/back-button`
+
+- [ ] **Step 1: Replace the page file content**
+
+Replace the entire `page.tsx` with:
+
+```tsx
+"use server";
+
+import AiSummaryStream from "@/components/article/ai-summary-stream";
+import ArticleCardActions from "@/components/article/article-card-actions";
+import ArticleMeta from "@/components/article/article-meta";
+import IntlRelativeTime from "@/components/intl-relative-time";
+import BackButton from "@/components/navigation/back-button";
+import TopNavigation from "@/components/navigation/top-navigation";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { auth } from "@/lib/auth";
+import prisma from "@/lib/prismaClient";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import readingTime from "reading-time";
+
+const AiSummary = async (props0: {
+  params: Promise<{ feedId: string; articleId: string }>;
+}) => {
+  const params = await props0.params;
+  let articleId = parseInt(params.articleId);
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return null;
+  }
+
+  const article = await prisma.article.findUnique({
+    include: {
+      feed: true,
+      scrape: true,
+    },
+    where: {
+      id: articleId,
+      userId: session.user.id,
+    },
+  });
+  if (!article) {
+    notFound();
+  }
+
+  const articleReadingTime = article.scrape
+    ? readingTime(article.scrape.textContent)
+    : undefined;
+
+  return (
+    <div className="m-2 flex flex-col gap-2">
+      <TopNavigation
+        segments={[
+          { name: "Feeds", href: "/feed" },
+          { name: article.feed.title, href: `/feed/${article.feed.id}` },
+        ]}
+        page="AI Summary"
+      />
+
+      <article className="mx-auto flex max-w-4xl flex-col gap-4">
+        <BackButton />
+
+        <div className="flex items-baseline gap-2 text-base">
+          <span className="text-muted-foreground font-semibold tracking-wide uppercase">
+            {article.feed.title}
+          </span>
+          <span className="text-muted-foreground">·</span>
+          <span className="text-muted-foreground">
+            <IntlRelativeTime date={article.publicationDate} />
+          </span>
+        </div>
+
+        <h2 className="text-2xl font-bold tracking-tight">{article.title}</h2>
+
+        <ArticleMeta author={article.scrape?.author} />
+
+        {article.scrape ? (
+          <AiSummaryStream articleId={article.id} />
+        ) : (
+          <Alert className="mx-auto my-12 max-w-md">
+            <AlertTitle>Summary unavailable</AlertTitle>
+            <AlertDescription>
+              The article content could not be retrieved, so an AI summary
+              cannot be generated.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="text-muted-foreground text-sm">
+          Source: <Link href={article.link}>{article.link}</Link>
+        </div>
+
+        <div className="flex flex-col gap-3 border-t pt-4 md:flex-row md:items-center md:gap-2">
+          <ArticleCardActions
+            article={article}
+            hideSummarizeButton
+            readingTime={articleReadingTime}
+          />
+        </div>
+      </article>
+    </div>
+  );
+};
+
+export default AiSummary;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Visually verify the AI Summary page**
+
+With dev server running, navigate to any article's AI Summary page. Check:
+- `BackButton` appears at the top of the article area
+- Article header (feed name, date, title, author) appears below
+- AI summary stream renders
+- Source link appears after summary
+- Action bar appears at the bottom with reading time and buttons
+- Desktop: single row layout
+- Mobile (resize to < 768px): two-row layout, no Summarize button visible
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
+git commit -m "feat: restructure AI summary page layout to match ArticleCard design"
+```

--- a/docs/superpowers/plans/2026-06-17-ai-summary-page-action-alignment.md
+++ b/docs/superpowers/plans/2026-06-17-ai-summary-page-action-alignment.md
@@ -1,35 +1,59 @@
 # AI Summary Page Action Button Alignment Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Align the AI Summary page action button layout with ArticleCard by consolidating responsive layout and reading time into `ArticleCardActions`, moving the back button out of that component, and restructuring the AI Summary page layout.
+**Goal:** Align the AI Summary page action button layout with ArticleCard by
+consolidating responsive layout and reading time into `ArticleCardActions`,
+moving the back button out of that component, and restructuring the AI Summary
+page layout.
 
-**Architecture:** The responsive two-row mobile layout currently duplicated in `ArticleCard`'s footer moves into `ArticleCardActions`, which gains an optional `readingTime` prop. `ArticleCard` simplifies its footer to a single `ArticleCardActions` call. The AI Summary page restructures its layout to show a standalone `BackButton` at the top and `ArticleCardActions` at the bottom after the summary content.
+**Architecture:** The responsive two-row mobile layout currently duplicated in
+`ArticleCard`'s footer moves into `ArticleCardActions`, which gains an optional
+`readingTime` prop. `ArticleCard` simplifies its footer to a single
+`ArticleCardActions` call. The AI Summary page restructures its layout to show a
+standalone `BackButton` at the top and `ArticleCardActions` at the bottom after
+the summary content.
 
-**Tech Stack:** Next.js 15 App Router, React, TypeScript, Tailwind CSS, Prisma, `reading-time` npm package, shadcn/ui components
+**Tech Stack:** Next.js 15 App Router, React, TypeScript, Tailwind CSS, Prisma,
+`reading-time` npm package, shadcn/ui components
 
 ## Global Constraints
 
 - No new dependencies
 - Follow existing Tailwind class patterns (see `article-card.tsx` for reference)
 - All TypeScript — no `any` types
-- `reading-time` package is already installed; import as `import readingTime from "reading-time"`
-- `ReadingTime` result type: `{ text: string; minutes: number; time: number; words: number }`
+- `reading-time` package is already installed; import as
+  `import readingTime from "reading-time"`
+- `ReadingTime` result type:
+  `{ text: string; minutes: number; time: number; words: number }`
 
 ---
 
 ### Task 1: Refactor `ArticleCardActions` — remove back button, add responsive layout and `readingTime` prop
 
 **Files:**
+
 - Modify: `src/components/article/article-card-actions.tsx`
 
 **Interfaces:**
+
 - Produces:
+
   ```ts
   interface ArticleCardActionsProps {
-    article: Prisma.ArticleGetPayload<{ include: { feed: true; scrape: true } }>;
+    article: Prisma.ArticleGetPayload<{
+      include: { feed: true; scrape: true };
+    }>;
     hideSummarizeButton?: boolean;
-    readingTime?: { text: string; minutes: number; time: number; words: number };
+    readingTime?: {
+      text: string;
+      minutes: number;
+      time: number;
+      words: number;
+    };
   }
   ```
 
@@ -135,7 +159,8 @@ cd /home/marcus/Documents/Programming/briefing-officer
 npx tsc --noEmit
 ```
 
-Expected: no errors (there will be type errors in `article-card.tsx` about the removed props — that's fine, they'll be fixed in Task 2).
+Expected: no errors (there will be type errors in `article-card.tsx` about the
+removed props — that's fine, they'll be fixed in Task 2).
 
 - [ ] **Step 3: Commit**
 
@@ -149,14 +174,17 @@ git commit -m "refactor: consolidate responsive layout and readingTime into Arti
 ### Task 2: Simplify `ArticleCard` footer
 
 **Files:**
+
 - Modify: `src/components/article/article-card.tsx`
 
 **Interfaces:**
+
 - Consumes: `ArticleCardActions` with props `{ article, readingTime? }`
 
 - [ ] **Step 1: Replace the CardFooter section**
 
-In `src/components/article/article-card.tsx`, replace the entire `<CardFooter>` block (lines 143–186) with:
+In `src/components/article/article-card.tsx`, replace the entire `<CardFooter>`
+block (lines 143–186) with:
 
 ```tsx
 <CardFooter className="flex-col gap-3 border-t px-4 md:flex md:flex-row md:items-center md:gap-2 md:px-6">
@@ -182,8 +210,10 @@ npm run dev
 ```
 
 Open `http://localhost:3000/feed` in a browser. Check:
+
 - Desktop: single row with reading time left, all action buttons right
-- Mobile (resize to < 768px): two rows — row 1 icon buttons with reading time, row 2 full-width Dismiss/Summarize/Visit
+- Mobile (resize to < 768px): two rows — row 1 icon buttons with reading time,
+  row 2 full-width Dismiss/Summarize/Visit
 
 - [ ] **Step 4: Commit**
 
@@ -197,10 +227,13 @@ git commit -m "refactor: simplify ArticleCard footer to use ArticleCardActions"
 ### Task 3: Restructure the AI Summary page
 
 **Files:**
+
 - Modify: `src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx`
 
 **Interfaces:**
-- Consumes: `ArticleCardActions` with props `{ article, hideSummarizeButton: true, readingTime? }`
+
+- Consumes: `ArticleCardActions` with props
+  `{ article, hideSummarizeButton: true, readingTime? }`
 - Consumes: `BackButton` from `@/components/navigation/back-button`
 
 - [ ] **Step 1: Replace the page file content**
@@ -322,6 +355,7 @@ Expected: no errors.
 - [ ] **Step 3: Visually verify the AI Summary page**
 
 With dev server running, navigate to any article's AI Summary page. Check:
+
 - `BackButton` appears at the top of the article area
 - Article header (feed name, date, title, author) appears below
 - AI summary stream renders

--- a/docs/superpowers/specs/2026-06-17-ai-summary-page-action-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-17-ai-summary-page-action-alignment-design.md
@@ -5,14 +5,21 @@
 
 ## Problem
 
-The action buttons on the AI Summary page (`/feed/[feedId]/article/[articleId]/ai-summary`) have diverged from the improved design in `ArticleCard`. The card has a responsive two-row mobile layout and desktop single-row layout. The AI Summary page renders `ArticleCardActions` directly (desktop-only layout) above the article header, with no reading time and a back button mixed into the action bar.
+The action buttons on the AI Summary page
+(`/feed/[feedId]/article/[articleId]/ai-summary`) have diverged from the
+improved design in `ArticleCard`. The card has a responsive two-row mobile
+layout and desktop single-row layout. The AI Summary page renders
+`ArticleCardActions` directly (desktop-only layout) above the article header,
+with no reading time and a back button mixed into the action bar.
 
 ## Goals
 
 - Align the AI Summary page action button layout with `ArticleCard`
-- Move responsive layout logic into `ArticleCardActions` (single source of truth)
+- Move responsive layout logic into `ArticleCardActions` (single source of
+  truth)
 - Move reading time display into `ArticleCardActions` (shared by both surfaces)
-- Move the back button out of `ArticleCardActions` — each page manages its own navigation
+- Move the back button out of `ArticleCardActions` — each page manages its own
+  navigation
 - Place action buttons below the article summary on the AI Summary page
 - Simplify the `ArticleCard` footer by removing duplicated mobile layout JSX
 
@@ -21,42 +28,58 @@ The action buttons on the AI Summary page (`/feed/[feedId]/article/[articleId]/a
 ### `ArticleCardActions` changes
 
 **Props:**
+
 - Remove `showBackButton` — callers manage their own back navigation
-- Rename `hideAiSummary` → `hideSummarizeButton` — kept to suppress the Summarize button on the AI Summary page itself
-- Add `readingTime?: ReturnType<typeof readingTime>` — optional pre-computed reading time; when present, renders the clock + text left-aligned
+- Rename `hideAiSummary` → `hideSummarizeButton` — kept to suppress the
+  Summarize button on the AI Summary page itself
+- Add `readingTime?: ReturnType<typeof readingTime>` — optional pre-computed
+  reading time; when present, renders the clock + text left-aligned
 
 **Responsive layout (moved in from `ArticleCard`):**
 
 Mobile — two rows:
-- Row 1: reading time (left), icon-only buttons — ReadLater, Starred, Comments (right)
+
+- Row 1: reading time (left), icon-only buttons — ReadLater, Starred, Comments
+  (right)
 - Row 2: full-width labeled buttons — Dismiss, Summarize (if not hidden), Visit
 
 Desktop — single row:
+
 - Reading time left-aligned, all buttons right-aligned (existing behavior)
 
 **Separator + BackButton** JSX is removed entirely.
 
 ### `ArticleCard` changes
 
-The mobile two-row layout JSX in the `<CardFooter>` is removed. The footer becomes a single `<ArticleCardActions article={article} readingTime={articleReadingTime} />` call for both mobile and desktop.
+The mobile two-row layout JSX in the `<CardFooter>` is removed. The footer
+becomes a single
+`<ArticleCardActions article={article} readingTime={articleReadingTime} />` call
+for both mobile and desktop.
 
 ### AI Summary page changes
 
-**Prisma query:** Add `scrape: true` to the include so reading time can be computed.
+**Prisma query:** Add `scrape: true` to the include so reading time can be
+computed.
 
 **Layout (top to bottom):**
+
 1. `TopNavigation` (breadcrumbs — unchanged)
 2. `BackButton` (standalone, replaces the old `showBackButton` prop usage)
 3. Article header: feed name · date, title, author
 4. `AiSummaryStream` (the summary content)
 5. Source link
-6. `ArticleCardActions article={article} hideSummarizeButton readingTime={articleReadingTime}` — action bar at the bottom, matching card placement
+6. `ArticleCardActions article={article} hideSummarizeButton readingTime={articleReadingTime}`
+   — action bar at the bottom, matching card placement
 
 ## Files Affected
 
-- `src/components/article/article-card-actions.tsx` — responsive layout, new `readingTime` prop, remove back button logic, rename prop
-- `src/components/article/article-card.tsx` — simplify footer, remove duplicated mobile layout JSX
-- `src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx` — add scrape to query, restructure layout, add standalone BackButton, move ArticleCardActions to bottom
+- `src/components/article/article-card-actions.tsx` — responsive layout, new
+  `readingTime` prop, remove back button logic, rename prop
+- `src/components/article/article-card.tsx` — simplify footer, remove duplicated
+  mobile layout JSX
+- `src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx` — add scrape
+  to query, restructure layout, add standalone BackButton, move
+  ArticleCardActions to bottom
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-06-17-ai-summary-page-action-alignment-design.md
+++ b/docs/superpowers/specs/2026-06-17-ai-summary-page-action-alignment-design.md
@@ -1,0 +1,65 @@
+# AI Summary Page Action Button Alignment
+
+**Date:** 2026-06-17  
+**Status:** Approved
+
+## Problem
+
+The action buttons on the AI Summary page (`/feed/[feedId]/article/[articleId]/ai-summary`) have diverged from the improved design in `ArticleCard`. The card has a responsive two-row mobile layout and desktop single-row layout. The AI Summary page renders `ArticleCardActions` directly (desktop-only layout) above the article header, with no reading time and a back button mixed into the action bar.
+
+## Goals
+
+- Align the AI Summary page action button layout with `ArticleCard`
+- Move responsive layout logic into `ArticleCardActions` (single source of truth)
+- Move reading time display into `ArticleCardActions` (shared by both surfaces)
+- Move the back button out of `ArticleCardActions` — each page manages its own navigation
+- Place action buttons below the article summary on the AI Summary page
+- Simplify the `ArticleCard` footer by removing duplicated mobile layout JSX
+
+## Design
+
+### `ArticleCardActions` changes
+
+**Props:**
+- Remove `showBackButton` — callers manage their own back navigation
+- Rename `hideAiSummary` → `hideSummarizeButton` — kept to suppress the Summarize button on the AI Summary page itself
+- Add `readingTime?: ReturnType<typeof readingTime>` — optional pre-computed reading time; when present, renders the clock + text left-aligned
+
+**Responsive layout (moved in from `ArticleCard`):**
+
+Mobile — two rows:
+- Row 1: reading time (left), icon-only buttons — ReadLater, Starred, Comments (right)
+- Row 2: full-width labeled buttons — Dismiss, Summarize (if not hidden), Visit
+
+Desktop — single row:
+- Reading time left-aligned, all buttons right-aligned (existing behavior)
+
+**Separator + BackButton** JSX is removed entirely.
+
+### `ArticleCard` changes
+
+The mobile two-row layout JSX in the `<CardFooter>` is removed. The footer becomes a single `<ArticleCardActions article={article} readingTime={articleReadingTime} />` call for both mobile and desktop.
+
+### AI Summary page changes
+
+**Prisma query:** Add `scrape: true` to the include so reading time can be computed.
+
+**Layout (top to bottom):**
+1. `TopNavigation` (breadcrumbs — unchanged)
+2. `BackButton` (standalone, replaces the old `showBackButton` prop usage)
+3. Article header: feed name · date, title, author
+4. `AiSummaryStream` (the summary content)
+5. Source link
+6. `ArticleCardActions article={article} hideSummarizeButton readingTime={articleReadingTime}` — action bar at the bottom, matching card placement
+
+## Files Affected
+
+- `src/components/article/article-card-actions.tsx` — responsive layout, new `readingTime` prop, remove back button logic, rename prop
+- `src/components/article/article-card.tsx` — simplify footer, remove duplicated mobile layout JSX
+- `src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx` — add scrape to query, restructure layout, add standalone BackButton, move ArticleCardActions to bottom
+
+## Out of Scope
+
+- Changes to individual button components (ToggleReadButton, VisitButton, etc.)
+- Changes to `TopNavigation`
+- Any new button types or behaviors

--- a/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
+++ b/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
@@ -82,7 +82,7 @@ const AiSummary = async (props0: {
           </Alert>
         )}
 
-        <div className="text-muted-foreground text-sm">
+        <div className="text-muted-foreground text-xs">
           Source: <Link href={article.link}>{article.link}</Link>
         </div>
 

--- a/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
+++ b/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
@@ -4,6 +4,7 @@ import AiSummaryStream from "@/components/article/ai-summary-stream";
 import ArticleCardActions from "@/components/article/article-card-actions";
 import ArticleMeta from "@/components/article/article-meta";
 import IntlRelativeTime from "@/components/intl-relative-time";
+import BackButton from "@/components/navigation/back-button";
 import TopNavigation from "@/components/navigation/top-navigation";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { auth } from "@/lib/auth";
@@ -11,6 +12,7 @@ import prisma from "@/lib/prismaClient";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import readingTime from "reading-time";
 
 const AiSummary = async (props0: {
   params: Promise<{ feedId: string; articleId: string }>;
@@ -37,6 +39,10 @@ const AiSummary = async (props0: {
     notFound();
   }
 
+  const articleReadingTime = article.scrape
+    ? readingTime(article.scrape.textContent)
+    : undefined;
+
   return (
     <div className="m-2 flex flex-col gap-2">
       <TopNavigation
@@ -48,7 +54,7 @@ const AiSummary = async (props0: {
       />
 
       <article className="mx-auto flex max-w-4xl flex-col gap-4">
-        <ArticleCardActions article={article} hideAiSummary showBackButton />
+        <BackButton />
 
         <div className="flex items-baseline gap-2 text-base">
           <span className="text-muted-foreground font-semibold tracking-wide uppercase">
@@ -78,6 +84,14 @@ const AiSummary = async (props0: {
 
         <div className="text-muted-foreground text-sm">
           Source: <Link href={article.link}>{article.link}</Link>
+        </div>
+
+        <div className="flex flex-col gap-3 border-t pt-4 md:flex-row md:items-center md:gap-2">
+          <ArticleCardActions
+            article={article}
+            hideSummarizeButton
+            readingTime={articleReadingTime}
+          />
         </div>
       </article>
     </div>

--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -43,11 +43,13 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
         <AiSummaryButton
           feedId={props.article.feedId}
           articleId={props.article.id}
+          size="sm"
           className="flex-1 justify-center text-sm"
         />
       )}
       <VisitButton
         article={props.article}
+        size="sm"
         className="flex-1 justify-center text-sm"
       />
     </div>

--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -32,7 +32,9 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
   <>
     {/* Mobile: row 1 — reading time left, icon buttons right */}
     <div className="flex w-full items-center gap-2 md:hidden">
-      {props.readingTime && <ReadingTimeLabel readingTime={props.readingTime} />}
+      {props.readingTime && (
+        <ReadingTimeLabel readingTime={props.readingTime} />
+      )}
       <div className="grow" />
       <ToggleReadLaterButton article={props.article} variant="ghost" />
       <ToggleStarredButton article={props.article} variant="ghost" />
@@ -62,7 +64,9 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
 
     {/* Desktop: single row */}
     <div className="hidden md:flex md:w-full md:items-center md:gap-2">
-      {props.readingTime && <ReadingTimeLabel readingTime={props.readingTime} />}
+      {props.readingTime && (
+        <ReadingTimeLabel readingTime={props.readingTime} />
+      )}
       <div className="grow" />
       <ToggleReadLaterButton article={props.article} />
       <ToggleStarredButton article={props.article} />

--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -17,16 +17,22 @@ interface ArticleCardActionsProps {
   readingTime?: { text: string; minutes: number; time: number; words: number };
 }
 
+const ReadingTimeLabel = ({
+  readingTime,
+}: {
+  readingTime: NonNullable<ArticleCardActionsProps["readingTime"]>;
+}) => (
+  <span className="text-muted-foreground flex items-center gap-1 text-xs">
+    <ClockIcon className="size-3" />
+    {readingTime.text}
+  </span>
+);
+
 const ArticleCardActions = (props: ArticleCardActionsProps) => (
   <>
     {/* Mobile: row 1 — reading time left, icon buttons right */}
     <div className="flex w-full items-center gap-2 md:hidden">
-      {props.readingTime && (
-        <span className="text-muted-foreground flex items-center gap-1 text-xs">
-          <ClockIcon className="size-3" />
-          {props.readingTime.text}
-        </span>
-      )}
+      {props.readingTime && <ReadingTimeLabel readingTime={props.readingTime} />}
       <div className="grow" />
       <ToggleReadLaterButton article={props.article} variant="ghost" />
       <ToggleStarredButton article={props.article} variant="ghost" />
@@ -56,12 +62,7 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
 
     {/* Desktop: single row */}
     <div className="hidden md:flex md:w-full md:items-center md:gap-2">
-      {props.readingTime && (
-        <span className="text-muted-foreground flex items-center gap-1 text-xs">
-          <ClockIcon className="size-3" />
-          {props.readingTime.text}
-        </span>
-      )}
+      {props.readingTime && <ReadingTimeLabel readingTime={props.readingTime} />}
       <div className="grow" />
       <ToggleReadLaterButton article={props.article} />
       <ToggleStarredButton article={props.article} />

--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -6,54 +6,83 @@ import ToggleReadButton from "@/components/article/toggle-read-button";
 import ToggleReadLaterButton from "@/components/article/toggle-read-later-button";
 import ToggleStarredButton from "@/components/article/toggle-starred-button";
 import VisitButton from "@/components/article/visit-button";
-import BackButton from "@/components/navigation/back-button";
-import { Separator } from "@/components/ui/separator";
 import { Prisma } from "@prisma/client";
+import { ClockIcon } from "lucide-react";
 
 interface ArticleCardActionsProps {
   article: Prisma.ArticleGetPayload<{
     include: { feed: true; scrape: true };
   }>;
-  hideAiSummary?: boolean;
-  showBackButton?: boolean;
+  hideSummarizeButton?: boolean;
+  readingTime?: { text: string; minutes: number; time: number; words: number };
 }
 
 const ArticleCardActions = (props: ArticleCardActionsProps) => (
-  <div className="flex flex-wrap gap-2">
-    {props.showBackButton && (
-      <>
-        <BackButton />
+  <>
+    {/* Mobile: row 1 — reading time left, icon buttons right */}
+    <div className="flex w-full items-center gap-2 md:hidden">
+      {props.readingTime && (
+        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+          <ClockIcon className="size-3" />
+          {props.readingTime.text}
+        </span>
+      )}
+      <div className="grow" />
+      <ToggleReadLaterButton article={props.article} variant="ghost" />
+      <ToggleStarredButton article={props.article} variant="ghost" />
+      <CommentsButton article={props.article} variant="ghost" />
+    </div>
 
-        <Separator className="mx-1 h-auto py-4" orientation="vertical" />
-      </>
-    )}
+    {/* Mobile: row 2 — full-width labeled buttons */}
+    <div className="flex w-full gap-2 md:hidden">
+      <ToggleReadButton
+        article={props.article}
+        className="flex-1 justify-center text-sm"
+      />
+      {!props.hideSummarizeButton && (
+        <AiSummaryButton
+          feedId={props.article.feedId}
+          articleId={props.article.id}
+          className="flex-1 justify-center text-sm"
+        />
+      )}
+      <VisitButton
+        article={props.article}
+        className="flex-1 justify-center text-sm"
+      />
+    </div>
 
-    <ToggleReadLaterButton article={props.article} />
-
-    <ToggleStarredButton article={props.article} />
-
-    <CommentsButton article={props.article} />
-
-    <ToggleReadButton
-      article={props.article}
-      className="cursor-pointer justify-start text-sm"
-    />
-
-    {!props.hideAiSummary && (
-      <AiSummaryButton
-        feedId={props.article.feedId}
-        articleId={props.article.id}
+    {/* Desktop: single row */}
+    <div className="hidden md:flex md:w-full md:items-center md:gap-2">
+      {props.readingTime && (
+        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+          <ClockIcon className="size-3" />
+          {props.readingTime.text}
+        </span>
+      )}
+      <div className="grow" />
+      <ToggleReadLaterButton article={props.article} />
+      <ToggleStarredButton article={props.article} />
+      <CommentsButton article={props.article} />
+      <ToggleReadButton
+        article={props.article}
+        className="cursor-pointer justify-start text-sm"
+      />
+      {!props.hideSummarizeButton && (
+        <AiSummaryButton
+          feedId={props.article.feedId}
+          articleId={props.article.id}
+          size="sm"
+          className="justify-start text-sm"
+        />
+      )}
+      <VisitButton
+        article={props.article}
         size="sm"
         className="justify-start text-sm"
       />
-    )}
-
-    <VisitButton
-      article={props.article}
-      size="sm"
-      className="justify-start text-sm"
-    />
-  </div>
+    </div>
+  </>
 );
 
 export default ArticleCardActions;

--- a/src/components/article/article-card.tsx
+++ b/src/components/article/article-card.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import AiSummaryButton from "@/components/article/ai-summary-button";
 import ArticleCardActions from "@/components/article/article-card-actions";
 import ArticleMeta from "@/components/article/article-meta";
-import CommentsButton from "@/components/article/comments-button";
-import ToggleReadButton from "@/components/article/toggle-read-button";
-import ToggleReadLaterButton from "@/components/article/toggle-read-later-button";
-import ToggleStarredButton from "@/components/article/toggle-starred-button";
-import VisitButton from "@/components/article/visit-button";
 import IntlRelativeTime from "@/components/intl-relative-time";
 import {
   Card,
@@ -21,7 +15,7 @@ import {
   unmarkArticleAsRead,
 } from "@/lib/repository/articleRepository";
 import { Prisma } from "@prisma/client";
-import { ClockIcon, LoaderCircleIcon } from "lucide-react";
+import { LoaderCircleIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -141,48 +135,10 @@ const ArticleCard = (props: ArticleCardProps) => {
       <CardContent className="px-4 md:px-6">{description()}</CardContent>
 
       <CardFooter className="flex-col gap-3 border-t px-4 md:flex md:flex-row md:items-center md:gap-2 md:px-6">
-        {/* Mobile: row 1 — reading time left, icon buttons right */}
-        <div className="flex w-full items-center gap-2 md:hidden">
-          {articleReadingTime && (
-            <span className="text-muted-foreground flex items-center gap-1 text-xs">
-              <ClockIcon className="size-3" />
-              {articleReadingTime.text}
-            </span>
-          )}
-          <div className="grow" />
-          <ToggleReadLaterButton article={props.article} variant="ghost" />
-          <ToggleStarredButton article={props.article} variant="ghost" />
-          <CommentsButton article={props.article} variant="ghost" />
-        </div>
-
-        {/* Mobile: row 2 — Dismiss, Summarize, Read */}
-        <div className="flex w-full gap-2 md:hidden">
-          <ToggleReadButton
-            article={props.article}
-            className="flex-1 justify-center text-sm"
-          />
-          <AiSummaryButton
-            feedId={props.article.feedId}
-            articleId={props.article.id}
-            className="flex-1 justify-center text-sm"
-          />
-          <VisitButton
-            article={props.article}
-            className="flex-1 justify-center text-sm"
-          />
-        </div>
-
-        {/* Desktop: single row */}
-        <div className="hidden md:flex md:w-full md:items-center md:gap-2">
-          {articleReadingTime && (
-            <span className="text-muted-foreground flex items-center gap-1 text-xs">
-              <ClockIcon className="size-3" />
-              {articleReadingTime.text}
-            </span>
-          )}
-          <div className="grow" />
-          <ArticleCardActions article={props.article} />
-        </div>
+        <ArticleCardActions
+          article={props.article}
+          readingTime={articleReadingTime}
+        />
       </CardFooter>
     </Card>
   );

--- a/src/components/article/article-card.tsx
+++ b/src/components/article/article-card.tsx
@@ -50,7 +50,7 @@ const ArticleCard = (props: ArticleCardProps) => {
     "s",
     createHotkeyHandler(() => {
       router.push(
-        `/feed/${props.article.feed}/article/${props.article.id}/ai-summary`,
+        `/feed/${props.article.feedId}/article/${props.article.id}/ai-summary`,
       );
     }),
   );


### PR DESCRIPTION
## Summary

- Consolidates the responsive action button layout (mobile two-row, desktop single-row) and reading time display into `ArticleCardActions`, making it the single source of truth
- Removes the back button from `ArticleCardActions` — each page manages its own navigation
- Simplifies `ArticleCard`'s footer from ~44 lines of duplicated layout JSX to a single `<ArticleCardActions>` call
- Restructures the AI Summary page: standalone `BackButton` at the top, `ArticleCardActions` at the bottom after the summary content (matching the card layout)
- Adds reading time to the AI Summary page
- Extracts a `ReadingTimeLabel` local component to remove duplicated span markup
- Also fixes a pre-existing bug where the hotkey `s` interpolated the full `Feed` object into a URL instead of `feedId`

## Test plan

- [ ] Feed list: article cards show correct two-row mobile layout (reading time + icon buttons row 1, Dismiss/Summarize/Visit row 2) and single-row desktop layout
- [ ] AI Summary page: `Back` button at top, action bar with reading time at the bottom, no `Summarize` button present
- [ ] Hotkey `s` on a selected card navigates to the correct AI Summary URL
- [ ] Mobile button sizes are consistent between rows (all `sm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)