### PR TITLE
Navigate back on Dismiss from AI summary page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,9 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "24.9.1",
         "@types/react": "19.2.16",
         "@types/react-dom": "19.2.3",
@@ -93,6 +96,13 @@
         "typescript": "5.9.3",
         "vitest": "^4.1.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.81",
@@ -4793,6 +4803,107 @@
         "tailwindcss": "4.3.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -4802,6 +4913,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -6343,6 +6462,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
@@ -6701,6 +6827,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8300,6 +8434,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9495,6 +9639,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9612,6 +9767,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -10385,6 +10550,55 @@
         }
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prisma": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
@@ -10988,6 +11202,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -11755,6 +11983,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:components": "vitest run --project components"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
@@ -93,6 +94,9 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "24.9.1",
     "@types/react": "19.2.16",
     "@types/react-dom": "19.2.3",

--- a/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
+++ b/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
@@ -1,7 +1,7 @@
 "use server";
 
+import AiSummaryArticleActions from "@/components/article/ai-summary-article-actions";
 import AiSummaryStream from "@/components/article/ai-summary-stream";
-import ArticleCardActions from "@/components/article/article-card-actions";
 import ArticleMeta from "@/components/article/article-meta";
 import IntlRelativeTime from "@/components/intl-relative-time";
 import BackButton from "@/components/navigation/back-button";
@@ -12,7 +12,6 @@ import prisma from "@/lib/prismaClient";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import readingTime from "reading-time";
 
 const AiSummary = async (props0: {
   params: Promise<{ feedId: string; articleId: string }>;
@@ -38,10 +37,6 @@ const AiSummary = async (props0: {
   if (!article) {
     notFound();
   }
-
-  const articleReadingTime = article.scrape
-    ? readingTime(article.scrape.textContent)
-    : undefined;
 
   return (
     <div className="m-2 flex flex-col gap-2">
@@ -85,11 +80,7 @@ const AiSummary = async (props0: {
           Source: <Link href={article.link}>{article.link}</Link>
         </div>
         <div className="flex flex-col gap-3 border-t pt-4 md:flex-row md:items-center md:gap-2">
-          <ArticleCardActions
-            article={article}
-            hideSummarizeButton
-            readingTime={articleReadingTime}
-          />
+          <AiSummaryArticleActions article={article} />
         </div>
       </article>
     </div>

--- a/src/components/article/ai-summary-article-actions.tsx
+++ b/src/components/article/ai-summary-article-actions.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import ArticleCardActions from "@/components/article/article-card-actions";
+import { Prisma } from "@prisma/client";
+import { useRouter } from "next/navigation";
+import readingTime from "reading-time";
+
+type Article = Prisma.ArticleGetPayload<{
+  include: { feed: true; scrape: true };
+}>;
+
+const AiSummaryArticleActions = ({ article }: { article: Article }) => {
+  const router = useRouter();
+  const articleReadingTime = article.scrape
+    ? readingTime(article.scrape.textContent)
+    : undefined;
+
+  return (
+    <ArticleCardActions
+      article={article}
+      hideSummarizeButton
+      readingTime={articleReadingTime}
+      onAfterDismiss={() => router.back()}
+    />
+  );
+};
+
+export default AiSummaryArticleActions;

--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -14,6 +14,7 @@ interface ArticleCardActionsProps {
     include: { feed: true; scrape: true };
   }>;
   hideSummarizeButton?: boolean;
+  onAfterDismiss?: () => void;
   readingTime?: { text: string; minutes: number; time: number; words: number };
 }
 
@@ -46,6 +47,7 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
       <ToggleReadButton
         article={props.article}
         className="flex-1 justify-center text-sm"
+        onAfterDismiss={props.onAfterDismiss}
       />
       {!props.hideSummarizeButton && (
         <AiSummaryButton
@@ -74,6 +76,7 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
       <ToggleReadButton
         article={props.article}
         className="cursor-pointer justify-start text-sm"
+        onAfterDismiss={props.onAfterDismiss}
       />
       {!props.hideSummarizeButton && (
         <AiSummaryButton

--- a/src/components/article/toggle-read-button.tsx
+++ b/src/components/article/toggle-read-button.tsx
@@ -12,9 +12,11 @@ import { toast } from "sonner";
 const ToggleReadButton = ({
   article,
   className,
+  onAfterDismiss,
 }: {
   article: Article;
   className?: string;
+  onAfterDismiss?: () => void;
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -22,6 +24,7 @@ const ToggleReadButton = ({
     setIsSubmitting(true);
     await markArticleAsRead(article.id);
     setIsSubmitting(false);
+    onAfterDismiss?.();
 
     toast("Article marked as read", {
       description: <span className="italic">{article.title}</span>,

--- a/tests/components/article/toggle-read-button.test.tsx
+++ b/tests/components/article/toggle-read-button.test.tsx
@@ -1,0 +1,50 @@
+import ToggleReadButton from "@/components/article/toggle-read-button";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/repository/articleRepository", () => ({
+  markArticleAsRead: vi.fn().mockResolvedValue(undefined),
+  unmarkArticleAsRead: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("sonner", () => ({
+  toast: vi.fn(),
+}));
+
+const unreadArticle = {
+  id: 1,
+  readAt: null,
+  title: "Test article",
+} as any;
+
+describe("ToggleReadButton", () => {
+  it("calls onAfterDismiss after marking as read", async () => {
+    const onAfterDismiss = vi.fn();
+    render(
+      <ToggleReadButton
+        article={unreadArticle}
+        onAfterDismiss={onAfterDismiss}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(onAfterDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onAfterDismiss when unmarking as read", async () => {
+    const onAfterDismiss = vi.fn();
+    const readArticle = { ...unreadArticle, readAt: new Date() };
+    render(
+      <ToggleReadButton
+        article={readArticle}
+        onAfterDismiss={onAfterDismiss}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /restore/i }));
+
+    expect(onAfterDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/setup.ts
+++ b/tests/components/setup.ts
@@ -1,0 +1,11 @@
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn(), back: vi.fn() })),
+  usePathname: vi.fn(() => "/"),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,22 +1,38 @@
 import { resolve } from "path";
 import { defineConfig } from "vitest/config";
 
+const alias = { "@": resolve(__dirname, "./src") };
+
 export default defineConfig({
   test: {
-    environment: "node",
-    setupFiles: ["./vitest.setup.ts"],
-    // Each file runs in its own worker (default pool), so per-worker DB
-    // isolation via VITEST_WORKER_ID prevents cross-file state bleed.
-    fileParallelism: true,
-    include: ["tests/unit/**/*.test.ts", "tests/integration/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      include: ["src/lib/**/*.ts"],
-    },
-  },
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "./src"),
-    },
+    projects: [
+      {
+        test: {
+          name: "node",
+          environment: "node",
+          setupFiles: ["./vitest.setup.ts"],
+          fileParallelism: true,
+          include: [
+            "tests/unit/**/*.test.ts",
+            "tests/integration/**/*.test.ts",
+          ],
+          coverage: {
+            provider: "v8",
+            include: ["src/lib/**/*.ts"],
+          },
+        },
+        resolve: { alias },
+      },
+      {
+        test: {
+          name: "components",
+          environment: "jsdom",
+          globals: true,
+          setupFiles: ["./tests/components/setup.ts"],
+          include: ["tests/components/**/*.test.tsx"],
+        },
+        resolve: { alias },
+      },
+    ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ const alias = { "@": resolve(__dirname, "./src") };
 
 export default defineConfig({
   test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/lib/**/*.ts"],
+    },
     projects: [
       {
         test: {
@@ -16,10 +20,6 @@ export default defineConfig({
             "tests/unit/**/*.test.ts",
             "tests/integration/**/*.test.ts",
           ],
-          coverage: {
-            provider: "v8",
-            include: ["src/lib/**/*.ts"],
-          },
         },
         resolve: { alias },
       },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds optional `onAfterDismiss` callback to `ToggleReadButton`, called after marking an article as read (not on Restore)
- Threads the prop through `ArticleCardActions` — existing callers pass nothing, so behavior is unchanged
- Adds `AiSummaryArticleActions` client wrapper that wires `router.back()` as the callback, keeping the server page component clean
- Sets up Vitest component testing infrastructure: jsdom project with React Testing Library (`npm run test:components`)

## Test plan

- [ ] Click Dismiss on the AI summary page — should mark article as read and navigate back
- [ ] Click Restore on the AI summary page — should toggle read state, no navigation
- [ ] Click Dismiss on an article card in the feed — behavior unchanged, no navigation
- [ ] `npm run test:components` passes
- [ ] `npm test` (node project) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)