### PR TITLE
feat: expose prometheus metrics

### DIFF
--- a/docs/superpowers/plans/2026-06-18-prometheus-metrics.md
+++ b/docs/superpowers/plans/2026-06-18-prometheus-metrics.md
@@ -1,0 +1,1454 @@
+# Prometheus Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose bearer-token protected Prometheus metrics at `/api/metrics`,
+including DB-backed gauges and runtime counters.
+
+**Architecture:** Add `prom-client` for runtime counters, a small repository for
+scrape-time DB gauge values, a formatter for gauge exposition text, and a
+Next.js route that joins gauges with runtime counter output. Instrument existing
+feed, AI lead, AI summary, and token usage paths through helper functions so
+metrics recording stays isolated from product behavior.
+
+**Tech Stack:** Next.js App Router route handlers, TypeScript, Prisma, Vitest,
+`prom-client`, SQLite test database.
+
+---
+
+## File Structure
+
+- Create `src/lib/metrics.ts`: Prometheus registry, runtime counter definitions,
+  reset helper for tests, and recording functions.
+- Create `src/lib/metricsRepository.ts`: Prisma queries for gauge values.
+- Create `src/lib/metricsFormatter.ts`: deterministic Prometheus text formatter
+  for DB-backed gauges.
+- Create `src/app/api/metrics/route.ts`: bearer-token auth, gauge collection,
+  runtime metric rendering, response status and content type.
+- Create `tests/unit/metrics.test.ts`: runtime counter and gauge formatter unit
+  tests.
+- Create `tests/integration/metricsRepository.test.ts`: DB-backed gauge query
+  tests.
+- Create `tests/integration/metricsRoute.test.ts`: route auth and response
+  tests.
+- Modify `src/lib/repository/feedRepository.ts`: record article scrape outcome
+  counters.
+- Modify `src/lib/ai/services/leadService.ts`: record AI lead outcome counters.
+- Modify `src/lib/ai/services/summaryService.ts`: record AI summary outcome
+  counters.
+- Modify `src/lib/ai/services/tokenUsageService.ts`: record language model token
+  counters.
+- Modify `tests/integration/feedRepository.test.ts`: assert scrape counters on
+  success and error.
+- Modify `tests/integration/leadService.test.ts`: assert AI lead and token
+  counters.
+- Modify or create `tests/integration/summaryService.test.ts`: assert AI summary
+  and token counters.
+- Modify `package.json` and `package-lock.json`: add `prom-client`.
+
+## Metrics Contract
+
+Gauges:
+
+```text
+briefing_officer_users_total
+briefing_officer_feeds_total{user_id}
+briefing_officer_articles_total{user_id,feed_name}
+briefing_officer_articles_unread_total{user_id,feed_name}
+briefing_officer_articles_read_later_total{user_id,feed_name}
+briefing_officer_articles_starred_total{user_id,feed_name}
+```
+
+Counters:
+
+```text
+briefing_officer_article_scrapes_total{user_id,feed_name,status="success|error"}
+briefing_officer_ai_lead_generations_total{user_id,feed_name,status="success|error"}
+briefing_officer_ai_summary_generations_total{user_id,feed_name,status="success|error"}
+briefing_officer_language_model_tokens_total{model,direction="input|output"}
+```
+
+## Task 1: Add Prometheus Client Dependency
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+- [ ] **Step 1: Install `prom-client`**
+
+Run:
+
+```bash
+npm install prom-client
+```
+
+Expected: `package.json` gains a `prom-client` dependency and
+`package-lock.json` is updated.
+
+- [ ] **Step 2: Verify dependency resolves**
+
+Run:
+
+```bash
+npm ls prom-client
+```
+
+Expected: output includes `prom-client@...` under `briefing-officer@0.10.0`.
+
+- [ ] **Step 3: Commit dependency update**
+
+Run:
+
+```bash
+git add package.json package-lock.json
+git commit -m "build: add prometheus client dependency" \
+  -m "Co-Authored-By: Codex <noreply@openai.com>" \
+  -m "Co-Authored-By: GPT-5 <noreply@openai.com>"
+```
+
+Expected: commit succeeds and Husky/lint-staged does not report errors.
+
+## Task 2: Runtime Counter Registry
+
+**Files:**
+
+- Create: `src/lib/metrics.ts`
+- Create: `tests/unit/metrics.test.ts`
+
+- [ ] **Step 1: Write failing runtime counter tests**
+
+Create `tests/unit/metrics.test.ts`:
+
+```ts
+import {
+  getMetricsText,
+  recordAiLeadGeneration,
+  recordAiSummaryGeneration,
+  recordArticleScrape,
+  recordLanguageModelTokens,
+  resetMetricsForTests,
+} from "@/lib/metrics";
+import { beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => {
+  resetMetricsForTests();
+});
+
+describe("runtime Prometheus metrics", () => {
+  it("records article scrape outcomes by user, feed, and status", async () => {
+    recordArticleScrape({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "success",
+    });
+    recordArticleScrape({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "error",
+    });
+
+    const output = await getMetricsText();
+
+    expect(output).toContain(
+      "# TYPE briefing_officer_article_scrapes_total counter",
+    );
+    expect(output).toContain(
+      'briefing_officer_article_scrapes_total{user_id="user-1",feed_name="Tech Feed",status="success"} 1',
+    );
+    expect(output).toContain(
+      'briefing_officer_article_scrapes_total{user_id="user-1",feed_name="Tech Feed",status="error"} 1',
+    );
+  });
+
+  it("records AI generation outcomes and language model tokens", async () => {
+    recordAiLeadGeneration({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "success",
+    });
+    recordAiSummaryGeneration({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "error",
+    });
+    recordLanguageModelTokens({
+      model: "test-model",
+      direction: "input",
+      tokens: 7,
+    });
+    recordLanguageModelTokens({
+      model: "test-model",
+      direction: "output",
+      tokens: 3,
+    });
+
+    const output = await getMetricsText();
+
+    expect(output).toContain(
+      'briefing_officer_ai_lead_generations_total{user_id="user-1",feed_name="Tech Feed",status="success"} 1',
+    );
+    expect(output).toContain(
+      'briefing_officer_ai_summary_generations_total{user_id="user-1",feed_name="Tech Feed",status="error"} 1',
+    );
+    expect(output).toContain(
+      'briefing_officer_language_model_tokens_total{model="test-model",direction="input"} 7',
+    );
+    expect(output).toContain(
+      'briefing_officer_language_model_tokens_total{model="test-model",direction="output"} 3',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+npm run test -- tests/unit/metrics.test.ts
+```
+
+Expected: FAIL because `@/lib/metrics` does not exist.
+
+- [ ] **Step 3: Implement runtime metrics module**
+
+Create `src/lib/metrics.ts`:
+
+```ts
+import { Counter, Registry } from "prom-client";
+
+export type OperationStatus = "success" | "error";
+export type TokenDirection = "input" | "output";
+
+type FeedEvent = {
+  userId: string;
+  feedName: string;
+  status: OperationStatus;
+};
+
+type TokenEvent = {
+  model: string;
+  direction: TokenDirection;
+  tokens: number;
+};
+
+let registry: Registry;
+let articleScrapes: Counter<"user_id" | "feed_name" | "status">;
+let aiLeadGenerations: Counter<"user_id" | "feed_name" | "status">;
+let aiSummaryGenerations: Counter<"user_id" | "feed_name" | "status">;
+let languageModelTokens: Counter<"model" | "direction">;
+
+const createRegistry = () => {
+  registry = new Registry();
+
+  articleScrapes = new Counter({
+    name: "briefing_officer_article_scrapes_total",
+    help: "Total article scrape attempts by outcome.",
+    labelNames: ["user_id", "feed_name", "status"],
+    registers: [registry],
+  });
+
+  aiLeadGenerations = new Counter({
+    name: "briefing_officer_ai_lead_generations_total",
+    help: "Total AI lead generation attempts by outcome.",
+    labelNames: ["user_id", "feed_name", "status"],
+    registers: [registry],
+  });
+
+  aiSummaryGenerations = new Counter({
+    name: "briefing_officer_ai_summary_generations_total",
+    help: "Total AI summary generation attempts by outcome.",
+    labelNames: ["user_id", "feed_name", "status"],
+    registers: [registry],
+  });
+
+  languageModelTokens = new Counter({
+    name: "briefing_officer_language_model_tokens_total",
+    help: "Total language model tokens used.",
+    labelNames: ["model", "direction"],
+    registers: [registry],
+  });
+};
+
+createRegistry();
+
+export const resetMetricsForTests = () => {
+  createRegistry();
+};
+
+export const recordArticleScrape = (event: FeedEvent) => {
+  articleScrapes.inc({
+    user_id: event.userId,
+    feed_name: event.feedName,
+    status: event.status,
+  });
+};
+
+export const recordAiLeadGeneration = (event: FeedEvent) => {
+  aiLeadGenerations.inc({
+    user_id: event.userId,
+    feed_name: event.feedName,
+    status: event.status,
+  });
+};
+
+export const recordAiSummaryGeneration = (event: FeedEvent) => {
+  aiSummaryGenerations.inc({
+    user_id: event.userId,
+    feed_name: event.feedName,
+    status: event.status,
+  });
+};
+
+export const recordLanguageModelTokens = (event: TokenEvent) => {
+  if (event.tokens <= 0) {
+    return;
+  }
+
+  languageModelTokens.inc(
+    { model: event.model, direction: event.direction },
+    event.tokens,
+  );
+};
+
+export const getMetricsText = () => registry.metrics();
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npm run test -- tests/unit/metrics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit runtime metrics module**
+
+Run:
+
+```bash
+git add src/lib/metrics.ts tests/unit/metrics.test.ts
+git commit -m "feat: add runtime metrics counters" \
+  -m "Co-Authored-By: Codex <noreply@openai.com>" \
+  -m "Co-Authored-By: GPT-5 <noreply@openai.com>"
+```
+
+Expected: commit succeeds.
+
+## Task 3: DB Gauge Collection and Formatting
+
+**Files:**
+
+- Create: `src/lib/metricsRepository.ts`
+- Create: `src/lib/metricsFormatter.ts`
+- Create: `tests/integration/metricsRepository.test.ts`
+- Modify: `tests/unit/metrics.test.ts`
+
+- [ ] **Step 1: Write failing formatter tests**
+
+Append to `tests/unit/metrics.test.ts`:
+
+```ts
+import { formatGaugeMetrics } from "@/lib/metricsFormatter";
+
+describe("gauge metric formatter", () => {
+  it("formats DB-backed gauges with HELP and TYPE lines", () => {
+    const output = formatGaugeMetrics({
+      usersTotal: 1,
+      feeds: [{ userId: "user-1", count: 2 }],
+      articles: [
+        {
+          userId: "user-1",
+          feedName: 'Tech "Daily"',
+          total: 3,
+          unread: 2,
+          readLater: 1,
+          starred: 1,
+        },
+      ],
+    });
+
+    expect(output).toContain("# TYPE briefing_officer_users_total gauge");
+    expect(output).toContain("briefing_officer_users_total 1");
+    expect(output).toContain(
+      'briefing_officer_feeds_total{user_id="user-1"} 2',
+    );
+    expect(output).toContain(
+      'briefing_officer_articles_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 3',
+    );
+    expect(output).toContain(
+      'briefing_officer_articles_unread_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 2',
+    );
+    expect(output).toContain(
+      'briefing_officer_articles_read_later_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 1',
+    );
+    expect(output).toContain(
+      'briefing_officer_articles_starred_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 1',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run formatter test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/unit/metrics.test.ts
+```
+
+Expected: FAIL because `@/lib/metricsFormatter` does not exist.
+
+- [ ] **Step 3: Implement gauge formatter**
+
+Create `src/lib/metricsFormatter.ts`:
+
+```ts
+export type GaugeMetrics = {
+  usersTotal: number;
+  feeds: Array<{ userId: string; count: number }>;
+  articles: Array<{
+    userId: string;
+    feedName: string;
+    total: number;
+    unread: number;
+    readLater: number;
+    starred: number;
+  }>;
+};
+
+const escapeLabelValue = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+
+const labels = (values: Record<string, string>) => {
+  const rendered = Object.entries(values)
+    .map(([key, value]) => `${key}="${escapeLabelValue(value)}"`)
+    .join(",");
+  return `{${rendered}}`;
+};
+
+const metric = (
+  name: string,
+  help: string,
+  rows: Array<{ labels?: Record<string, string>; value: number }>,
+) => {
+  const lines = [`# HELP ${name} ${help}`, `# TYPE ${name} gauge`];
+  rows.forEach((row) => {
+    lines.push(`${name}${row.labels ? labels(row.labels) : ""} ${row.value}`);
+  });
+  return lines.join("\n");
+};
+
+export const formatGaugeMetrics = (metrics: GaugeMetrics) => {
+  return [
+    metric("briefing_officer_users_total", "Current number of users.", [
+      { value: metrics.usersTotal },
+    ]),
+    metric("briefing_officer_feeds_total", "Current number of feeds by user.", [
+      ...metrics.feeds.map((feed) => ({
+        labels: { user_id: feed.userId },
+        value: feed.count,
+      })),
+    ]),
+    metric(
+      "briefing_officer_articles_total",
+      "Current number of articles by user and feed.",
+      metrics.articles.map((row) => ({
+        labels: { user_id: row.userId, feed_name: row.feedName },
+        value: row.total,
+      })),
+    ),
+    metric(
+      "briefing_officer_articles_unread_total",
+      "Current number of unread articles by user and feed.",
+      metrics.articles.map((row) => ({
+        labels: { user_id: row.userId, feed_name: row.feedName },
+        value: row.unread,
+      })),
+    ),
+    metric(
+      "briefing_officer_articles_read_later_total",
+      "Current number of read-later articles by user and feed.",
+      metrics.articles.map((row) => ({
+        labels: { user_id: row.userId, feed_name: row.feedName },
+        value: row.readLater,
+      })),
+    ),
+    metric(
+      "briefing_officer_articles_starred_total",
+      "Current number of starred articles by user and feed.",
+      metrics.articles.map((row) => ({
+        labels: { user_id: row.userId, feed_name: row.feedName },
+        value: row.starred,
+      })),
+    ),
+  ].join("\n\n");
+};
+```
+
+- [ ] **Step 4: Run formatter tests**
+
+Run:
+
+```bash
+npm run test -- tests/unit/metrics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing repository tests**
+
+Create `tests/integration/metricsRepository.test.ts`:
+
+```ts
+import { collectGaugeMetrics } from "@/lib/metricsRepository";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createArticle, createFeed, createUser } from "../helpers/factories";
+
+let userId: string;
+let feedId: number;
+
+beforeEach(async () => {
+  userId = (await createUser()).id;
+  feedId = (await createFeed({ userId, title: "Tech Feed" })).id;
+});
+
+describe("collectGaugeMetrics", () => {
+  it("collects user, feed, and article gauges", async () => {
+    await createArticle({ userId, feedId });
+    await createArticle({ userId, feedId, readAt: new Date() });
+    await createArticle({ userId, feedId, readLater: true });
+    await createArticle({ userId, feedId, starred: true });
+
+    const metrics = await collectGaugeMetrics();
+
+    expect(metrics).toEqual({
+      usersTotal: 1,
+      feeds: [{ userId, count: 1 }],
+      articles: [
+        {
+          userId,
+          feedName: "Tech Feed",
+          total: 4,
+          unread: 3,
+          readLater: 1,
+          starred: 1,
+        },
+      ],
+    });
+  });
+});
+```
+
+- [ ] **Step 6: Run repository test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- tests/integration/metricsRepository.test.ts
+```
+
+Expected: FAIL because `@/lib/metricsRepository` does not exist.
+
+- [ ] **Step 7: Implement gauge repository**
+
+Create `src/lib/metricsRepository.ts`:
+
+```ts
+import { GaugeMetrics } from "@/lib/metricsFormatter";
+import prisma from "@/lib/prismaClient";
+
+export const collectGaugeMetrics = async (): Promise<GaugeMetrics> => {
+  const usersTotal = await prisma.user.count();
+
+  const feedGroups = await prisma.feed.groupBy({
+    by: ["userId"],
+    _count: { _all: true },
+    orderBy: { userId: "asc" },
+  });
+
+  const feeds = feedGroups.map((row) => ({
+    userId: row.userId,
+    count: row._count._all,
+  }));
+
+  const feedRows = await prisma.feed.findMany({
+    select: { id: true, userId: true, title: true },
+    orderBy: [{ userId: "asc" }, { title: "asc" }, { id: "asc" }],
+  });
+
+  const articles = await Promise.all(
+    feedRows.map(async (feed) => {
+      const [total, unread, readLater, starred] = await Promise.all([
+        prisma.article.count({
+          where: { feedId: feed.id, userId: feed.userId },
+        }),
+        prisma.article.count({
+          where: { feedId: feed.id, userId: feed.userId, readAt: null },
+        }),
+        prisma.article.count({
+          where: { feedId: feed.id, userId: feed.userId, readLater: true },
+        }),
+        prisma.article.count({
+          where: { feedId: feed.id, userId: feed.userId, starred: true },
+        }),
+      ]);
+
+      return {
+        userId: feed.userId,
+        feedName: feed.title,
+        total,
+        unread,
+        readLater,
+        starred,
+      };
+    }),
+  );
+
+  return { usersTotal, feeds, articles };
+};
+```
+
+- [ ] **Step 8: Run gauge tests**
+
+Run:
+
+```bash
+npm run test -- tests/unit/metrics.test.ts tests/integration/metricsRepository.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit gauge collection and formatting**
+
+Run:
+
+```bash
+git add src/lib/metricsFormatter.ts src/lib/metricsRepository.ts tests/unit/metrics.test.ts tests/integration/metricsRepository.test.ts
+git commit -m "feat: add prometheus gauge metrics" \
+  -m "Co-Authored-By: Codex <noreply@openai.com>" \
+  -m "Co-Authored-By: GPT-5 <noreply@openai.com>"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Metrics Route
+
+**Files:**
+
+- Create: `src/app/api/metrics/route.ts`
+- Create: `tests/integration/metricsRoute.test.ts`
+
+- [ ] **Step 1: Write failing route tests**
+
+Create `tests/integration/metricsRoute.test.ts`:
+
+```ts
+import { GET } from "@/app/api/metrics/route";
+import { resetMetricsForTests, recordArticleScrape } from "@/lib/metrics";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createArticle, createFeed, createUser } from "../helpers/factories";
+
+const request = (token?: string) =>
+  new Request("http://localhost/api/metrics", {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+
+beforeEach(() => {
+  resetMetricsForTests();
+  delete process.env.METRICS_TOKEN;
+});
+
+describe("GET /api/metrics", () => {
+  it("returns 404 when metrics token is not configured", async () => {
+    const response = await GET(request());
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 401 when authorization is missing or wrong", async () => {
+    process.env.METRICS_TOKEN = "secret";
+
+    expect((await GET(request())).status).toBe(401);
+    expect((await GET(request("wrong"))).status).toBe(401);
+  });
+
+  it("returns gauge and counter metrics for a valid token", async () => {
+    process.env.METRICS_TOKEN = "secret";
+    const userId = (await createUser()).id;
+    const feed = await createFeed({ userId, title: "Tech Feed" });
+    await createArticle({ userId, feedId: feed.id });
+    recordArticleScrape({
+      userId,
+      feedName: "Tech Feed",
+      status: "success",
+    });
+
+    const response = await GET(request("secret"));
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; version=0.0.4; charset=utf-8",
+    );
+    expect(body).toContain("briefing_officer_users_total 1");
+    expect(body).toContain(
+      `briefing_officer_feeds_total{user_id="${userId}"} 1`,
+    );
+    expect(body).toContain(
+      `briefing_officer_article_scrapes_total{user_id="${userId}",feed_name="Tech Feed",status="success"} 1`,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run route tests to verify they fail**
+
+Run:
+
+```bash
+npm run test -- tests/integration/metricsRoute.test.ts
+```
+
+Expected: FAIL because `src/app/api/metrics/route.ts` does not exist.
+
+- [ ] **Step 3: Implement metrics route**
+
+Create `src/app/api/metrics/route.ts`:
+
+```ts
+import { getMetricsText } from "@/lib/metrics";
+import { formatGaugeMetrics } from "@/lib/metricsFormatter";
+import { collectGaugeMetrics } from "@/lib/metricsRepository";
+
+const contentType = "text/plain; version=0.0.4; charset=utf-8";
+
+const isAuthorized = (request: Request, token: string) => {
+  return request.headers.get("Authorization") === `Bearer ${token}`;
+};
+
+export const GET = async (request: Request) => {
+  const token = process.env.METRICS_TOKEN;
+  if (!token) {
+    return new Response("", { status: 404 });
+  }
+
+  if (!isAuthorized(request, token)) {
+    return new Response("", { status: 401 });
+  }
+
+  try {
+    const [gaugeMetrics, runtimeMetrics] = await Promise.all([
+      collectGaugeMetrics(),
+      getMetricsText(),
+    ]);
+
+    return new Response(
+      `${formatGaugeMetrics(gaugeMetrics)}\n\n${runtimeMetrics}`,
+      {
+        status: 200,
+        headers: { "Content-Type": contentType },
+      },
+    );
+  } catch (error) {
+    return new Response("Service Unavailable", { status: 503 });
+  }
+};
+```
+
+- [ ] **Step 4: Run route tests**
+
+Run:
+
+```bash
+npm run test -- tests/integration/metricsRoute.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit metrics route**
+
+Run:
+
+```bash
+git add src/app/api/metrics/route.ts tests/integration/metricsRoute.test.ts
+git commit -m "feat: expose prometheus metrics endpoint" \
+  -m "Co-Authored-By: Codex <noreply@openai.com>" \
+  -m "Co-Authored-By: GPT-5 <noreply@openai.com>"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Article Scrape Instrumentation
+
+**Files:**
+
+- Modify: `src/lib/repository/feedRepository.ts`
+- Modify: `tests/integration/feedRepository.test.ts`
+
+- [ ] **Step 1: Write failing scrape instrumentation tests**
+
+Add this mock near the other boundary mocks in
+`tests/integration/feedRepository.test.ts`:
+
+```ts
+vi.mock("@/lib/metrics", () => ({
+  recordArticleScrape: vi.fn(),
+}));
+```
+
+Add this import with the existing imports:
+
+```ts
+import { recordArticleScrape } from "@/lib/metrics";
+```
+
+Add these tests inside `describe("feedRepository.refreshFeed", () => { ... })`:
+
+```ts
+it("records successful article scrape metrics for new articles", async () => {
+  const feed = await createFeed({ userId, title: "Tech Feed" });
+  vi.mocked(scrapeFeed).mockResolvedValue([
+    feedItem("First", "https://example.com/1"),
+  ]);
+
+  await refreshFeed(feed.id);
+
+  expect(recordArticleScrape).toHaveBeenCalledWith({
+    userId,
+    feedName: "Tech Feed",
+    status: "success",
+  });
+});
+
+it("records failed article scrape metrics and continues processing", async () => {
+  const feed = await createFeed({ userId, title: "Tech Feed" });
+  vi.mocked(scrapeFeed).mockResolvedValue([
+    feedItem("First", "https://example.com/1"),
+  ]);
+  vi.mocked(scrapeArticle).mockRejectedValue(new Error("scrape failed"));
+
+  await refreshFeed(feed.id);
+
+  expect(recordArticleScrape).toHaveBeenCalledWith({
+    userId,
+    feedName: "Tech Feed",
+    status: "error",
+  });
+  expect(generateAiLead).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run feed repository tests to verify failure**
+
+Run:
+
+```bash
+npm run test -- tests/integration/feedRepository.test.ts
+```
+
+Expected: FAIL because `recordArticleScrape` is not called.
+
+- [ ] **Step 3: Implement scrape instrumentation**
+
+Modify `src/lib/repository/feedRepository.ts`.
+
+Add import:
+
+```ts
+import { recordArticleScrape } from "@/lib/metrics";
+```
+
+Change `processArticle`:
+
+```ts
+const processArticle = async (article: Article, feedName: string) => {
+  try {
+    await scrapeArticle(article.id, article.link);
+    recordArticleScrape({
+      userId: article.userId,
+      feedName,
+      status: "success",
+    });
+  } catch (error) {
+    recordArticleScrape({
+      userId: article.userId,
+      feedName,
+      status: "error",
+    });
+    logger.error(
+      { article: { id: article.id, title: article.title, link: article.link } },
+      "Failed to scrape article.",
+    );
+  }
+
+  try {
+    await generateAiLead(article.id);
+  } catch (error) {
+    logger.error(
+      { article: { id: article.id, title: article.title, link: article.link } },
+      "Failed to generate AI lead.",
+    );
+  }
+
+  revalidatePath(`/feed/${article.feedId}`);
+};
+```
+
+Change the created articles processing:
+
+```ts
+const processedArticles = createdArticles.map((article) =>
+  processArticle(article, feed.title),
+);
+```
+
+- [ ] **Step 4: Run feed repository tests**
+
+Run:
+
+```bash
+npm run test -- tests/integration/feedRepository.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit scrape instrumentation**
+
+Run:
+
+```bash
+git add src/lib/repository/feedRepository.ts tests/integration/feedRepository.test.ts
+git commit -m "feat: record article scrape metrics" \
+  -m "Co-Authored-By: Codex <noreply@openai.com>" \
+  -m "Co-Authored-By: GPT-5 <noreply@openai.com>"
+```
+
+Expected: commit succeeds.
+
+## Task 6: AI Lead and Token Instrumentation
+
+**Files:**
+
+- Modify: `src/lib/ai/services/leadService.ts`
+- Modify: `src/lib/ai/services/tokenUsageService.ts`
+- Modify: `tests/integration/leadService.test.ts`
+- Modify: `tests/integration/tokenUsageService.test.ts`
+
+- [ ] **Step 1: Write failing token usage metrics test**
+
+Add this mock to `tests/integration/tokenUsageService.test.ts`:
+
+```ts
+vi.mock("@/lib/metrics", () => ({
+  recordLanguageModelTokens: vi.fn(),
+}));
+```
+
+Update imports:
+
+```ts
+import { recordLanguageModelTokens } from "@/lib/metrics";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+```
+
+Add this assertion to the `"creates a usage row on first call"` test after the
+database assertions:
+
+```ts
+expect(recordLanguageModelTokens).toHaveBeenCalledWith({
+  model: "test-model",
+  direction: "input",
+  tokens: 10,
+});
+expect(recordLanguageModelTokens).toHaveBeenCalledWith({
+  model: "test-model",
+  direction: "output",
+  tokens: 5,
+});
+```
+
+- [ ] **Step 2: Run token usage test to verify failure**
+
+Run:
+
+```bash
+npm run test -- tests/integration/tokenUsageService.test.ts
+```
+
+Expected: FAIL because `recordLanguageModelTokens` is not called.
+
+- [ ] **Step 3: Implement token instrumentation**
+
+Modify `src/lib/ai/services/tokenUsageService.ts`.
+
+Add import:
+
+```ts
+import { recordLanguageModelTokens } from "@/lib/metrics";
+```
+
+Add this after the Prisma upsert:
+
+```ts
+recordLanguageModelTokens({
+  model,
+  direction: "input",
+  tokens: inputTokens,
+});
+recordLanguageModelTokens({
+  model,
+  direction: "output",
+  tokens: outputTokens,
+});
+```
+
+- [ ] **Step 4: Run token usage tests**
+
+Run:
+
+```bash
+npm run test -- tests/integration/tokenUsageService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing AI lead outcome tests**
+
+Add this to the metrics mock in `tests/integration/leadService.test.ts`:
+
+```ts
+vi.mock("@/lib/metrics", () => ({
+  recordAiLeadGeneration: vi.fn(),
+}));
+```
+
+Add import:
+
+```ts
+import { recordAiLeadGeneration } from "@/lib/metrics";
+```
+
+Update the `ai` mock so failures can be tested:
+
+```ts
+import { generateText } from "ai";
+```
+
+Add assertions to the existing success test:
+
+```ts
+expect(recordAiLeadGeneration).toHaveBeenCalledWith({
+  userId,
+  feedName: "Test Feed",
+  status: "success",
+});
+```
+
+Add a failure test:
+
+```ts
+it("records failed AI lead generation metrics", async () => {
+  const article = await createArticle({ userId, feedId });
+  vi.mocked(generateText).mockRejectedValueOnce(new Error("model failed"));
+
+  await expect(generateAiLead(article.id)).rejects.toThrow("model failed");
+
+  expect(recordAiLeadGeneration).toHaveBeenCalledWith({
+    userId,
+    feedName: "Test Feed",
+    status: "error",
+  });
+});
+```
+
+- [ ] **Step 6: Run AI lead tests to verify failure**
+
+Run:
+
+```bash
+npm run test -- tests/integration/leadService.test.ts
+```
+
+Expected: FAIL because `recordAiLeadGeneration` is not called and the article
+query does not include feed title.
+
+- [ ] **Step 7: Implement AI lead outcome instrumentation**
+
+Modify `src/lib/ai/services/leadService.ts`.
+
+Add import:
+
+```ts
+import { recordAiLeadGeneration } from "@/lib/metrics";
+```
+
+Change article query:
+
+```ts
+const article = await prisma.article.findUniqueOrThrow({
+  include: { scrape: true, feed: { select: { title: true } } },
+  where: { id: articleId },
+});
+```
+
+Wrap generation/persistence:
+
+```ts
+try {
+  const lead = await generateText({
+    model,
+    system: systemPrompt,
+    prompt: buildLeadPrompt(article.title, article.scrape?.textContent ?? ""),
+  });
+
+  await prisma.articleLead.upsert({
+    where: { articleId },
+    create: {
+      articleId,
+      text: lead.text,
+    },
+    update: {
+      text: lead.text,
+    },
+  });
+
+  recordAiLeadGeneration({
+    userId: article.userId,
+    feedName: article.feed.title,
+    status: "success",
+  });
+
+  await trackTokenUsage(
+    article.userId,
+    model.modelId,
+    lead.totalUsage.inputTokens ?? 0,
+    lead.totalUsage.outputTokens ?? 0,
+  );
+
+  logger.info(
+    {
+      articleId,
+      feedId: article.feedId,
+      model: model.modelId,
+      tokenUsage: lead.totalUsage,
+    },
+    "AI lead generated.",
+  );
+
+  return lead.text;
+} catch (error) {
+  recordAiLeadGeneration({
+    userId: article.userId,
+    feedName: article.feed.title,
+    status: "error",
+  });
+  throw error;
+}
+```
+
+- [ ] **Step 8: Run AI lead and token tests**
+
+Run:
+
+```bash
+npm run test -- tests/integration/leadService.test.ts tests/integration/tokenUsageService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit lead and token instrumentation**
+
+Run:
+
+```bash
+git add src/lib/ai/services/leadService.ts src/lib/ai/services/tokenUsageService.ts tests/integration/leadService.test.ts tests/integration/tokenUsageService.test.ts
+git commit -m "feat: record ai lead and token metrics" \
+  -m "Co-Authored-By: Codex <noreply@openai.com>" \
+  -m "Co-Authored-By: GPT-5 <noreply@openai.com>"
+```
+
+Expected: commit succeeds.
+
+## Task 7: AI Summary Instrumentation
+
+**Files:**
+
+- Modify: `src/lib/ai/services/summaryService.ts`
+- Create: `tests/integration/summaryService.test.ts`
+
+- [ ] **Step 1: Write failing AI summary tests**
+
+Create `tests/integration/summaryService.test.ts`:
+
+```ts
+import { recordAiSummaryGeneration } from "@/lib/metrics";
+import { getUserId } from "@/lib/repository/userRepository";
+import { streamText } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createArticle, createFeed, createUser } from "../helpers/factories";
+
+vi.mock("@/lib/repository/userRepository", () => ({
+  getUserId: vi.fn(),
+}));
+
+vi.mock("@ai-sdk/rsc", () => ({
+  createStreamableValue: vi.fn((initial: string) => ({
+    value: initial,
+    update: vi.fn(),
+    done: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/ai/registry", () => ({
+  getFirstConfiguredLanguageModel: vi.fn(async () => ({
+    modelId: "test-model",
+  })),
+}));
+
+vi.mock("ai", () => ({
+  streamText: vi.fn(() => ({
+    textStream: (async function* () {
+      yield "summary";
+    })(),
+    totalUsage: Promise.resolve({ inputTokens: 11, outputTokens: 4 }),
+  })),
+}));
+
+vi.mock("@/lib/metrics", () => ({
+  recordAiSummaryGeneration: vi.fn(),
+}));
+
+vi.mock("@/lib/ai/services/tokenUsageService", () => ({
+  trackTokenUsage: vi.fn(),
+}));
+
+import { trackTokenUsage } from "@/lib/ai/services/tokenUsageService";
+import { streamAiSummary } from "@/lib/ai/services/summaryService";
+
+let userId: string;
+let feedId: number;
+
+beforeEach(async () => {
+  userId = (await createUser()).id;
+  vi.mocked(getUserId).mockResolvedValue(userId);
+  feedId = (await createFeed({ userId, title: "Tech Feed" })).id;
+});
+
+describe("streamAiSummary", () => {
+  it("records successful summary and token metrics", async () => {
+    const article = await createArticle({ userId, feedId });
+
+    await streamAiSummary(article.id);
+    await vi.waitFor(() => {
+      expect(recordAiSummaryGeneration).toHaveBeenCalledWith({
+        userId,
+        feedName: "Tech Feed",
+        status: "success",
+      });
+    });
+
+    expect(trackTokenUsage).toHaveBeenCalledWith(userId, "test-model", 11, 4);
+  });
+
+  it("records failed summary metrics", async () => {
+    const article = await createArticle({ userId, feedId });
+    vi.mocked(streamText).mockImplementationOnce(() => {
+      throw new Error("stream failed");
+    });
+
+    await streamAiSummary(article.id);
+
+    await vi.waitFor(() => {
+      expect(recordAiSummaryGeneration).toHaveBeenCalledWith({
+        userId,
+        feedName: "Tech Feed",
+        status: "error",
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run summary tests to verify failure**
+
+Run:
+
+```bash
+npm run test -- tests/integration/summaryService.test.ts
+```
+
+Expected: FAIL because `recordAiSummaryGeneration` is not called and the article
+query does not include feed title.
+
+- [ ] **Step 3: Implement AI summary outcome instrumentation**
+
+Modify `src/lib/ai/services/summaryService.ts`.
+
+Add import:
+
+```ts
+import { recordAiSummaryGeneration } from "@/lib/metrics";
+```
+
+Change article query:
+
+```ts
+const article = await prisma.article.findUniqueOrThrow({
+  where: { id: articleId, userId },
+  include: { scrape: true, feed: { select: { title: true } } },
+});
+```
+
+Change the background task body:
+
+```ts
+void (async () => {
+  try {
+    const { textStream, totalUsage } = streamText({
+      model,
+      system: systemPrompt,
+      prompt: buildSummaryPrompt(
+        article.title,
+        article.scrape?.textContent ?? "",
+      ),
+    });
+
+    for await (const delta of textStream) {
+      stream.update(delta);
+    }
+
+    stream.done();
+
+    const tokenUsage = await totalUsage;
+
+    recordAiSummaryGeneration({
+      userId,
+      feedName: article.feed.title,
+      status: "success",
+    });
+
+    logger.info(
+      {
+        articleId,
+        feedId: article.feedId,
+        model: model.modelId,
+        tokenUsage,
+      },
+      "AI summary generated.",
+    );
+
+    await trackTokenUsage(
+      userId,
+      model.modelId,
+      tokenUsage.inputTokens ?? 0,
+      tokenUsage.outputTokens ?? 0,
+    );
+  } catch (error) {
+    recordAiSummaryGeneration({
+      userId,
+      feedName: article.feed.title,
+      status: "error",
+    });
+    stream.done();
+  }
+})();
+```
+
+- [ ] **Step 4: Run summary tests**
+
+Run:
+
+```bash
+npm run test -- tests/integration/summaryService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit summary instrumentation**
+
+Run:
+
+```bash
+git add src/lib/ai/services/summaryService.ts tests/integration/summaryService.test.ts
+git commit -m "feat: record ai summary metrics" \
+  -m "Co-Authored-By: Codex <noreply@openai.com>" \
+  -m "Co-Authored-By: GPT-5 <noreply@openai.com>"
+```
+
+Expected: commit succeeds.
+
+## Task 8: Final Verification
+
+**Files:**
+
+- Review all modified files.
+
+- [ ] **Step 1: Run focused metrics tests**
+
+Run:
+
+```bash
+npm run test -- tests/unit/metrics.test.ts tests/integration/metricsRepository.test.ts tests/integration/metricsRoute.test.ts tests/integration/feedRepository.test.ts tests/integration/leadService.test.ts tests/integration/tokenUsageService.test.ts tests/integration/summaryService.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run required checks**
+
+Run:
+
+```bash
+npm run format:check
+npm run lint
+npm run test
+npm run build
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: working tree is clean. Commits are Conventional Commits.
+
+- [ ] **Step 4: Push branch and open PR**
+
+Run:
+
+```bash
+git push -u origin feat/prometheus-metrics
+gh pr create --base main --head feat/prometheus-metrics --title "feat: expose prometheus metrics" --body "## Summary
+- expose bearer-token protected Prometheus metrics
+- add DB-backed gauge metrics
+- add runtime counters for scrape, AI generation, and token usage
+
+## Checks
+- npm run format:check
+- npm run lint
+- npm run test
+- npm run build"
+```
+
+Expected: PR is created against `main`. Do not merge without explicit user
+instruction.
+
+## Self-Review
+
+- Spec coverage: endpoint auth, DB gauges, runtime counters, token naming,
+  status labels, type distinction, cardinality, and tests are covered.
+- Placeholder scan: no placeholder markers or vague implementation steps are
+  present.
+- Type consistency: helper names and metric names are consistent across tasks.

--- a/docs/superpowers/specs/2026-06-18-prometheus-metrics-design.md
+++ b/docs/superpowers/specs/2026-06-18-prometheus-metrics-design.md
@@ -1,0 +1,233 @@
+# Design: Prometheus metrics endpoint
+
+**Date:** 2026-06-18
+
+## Goal
+
+Expose Prometheus-compatible metrics for operational monitoring. The endpoint
+must support both runtime counters and database-backed gauges, use Prometheus
+metric naming conventions, and require a bearer token configured through the
+environment.
+
+## Endpoint
+
+Add `GET /api/metrics`.
+
+Behavior:
+
+1. If `METRICS_TOKEN` is not configured, return `404`.
+2. If `METRICS_TOKEN` is configured but the request does not include
+   `Authorization: Bearer <token>`, return `401`.
+3. If the token matches, return Prometheus text exposition with
+   `Content-Type: text/plain; version=0.0.4; charset=utf-8`.
+4. If gauge collection fails, return `503` rather than partial metrics.
+
+The route is intentionally not tied to the app's Better Auth session. Prometheus
+scrapes authenticate with the metrics token only.
+
+## Metric Types
+
+The feature exposes two kinds of metrics:
+
+- **Gauges** represent current application state read from the database at
+  scrape time. They can go up or down between scrapes.
+- **Counters** represent runtime events recorded while the server process is
+  running. They only increase until the process restarts.
+
+This distinction is part of the metric contract and should be reflected in tests
+and `HELP`/`TYPE` output.
+
+## Metric Names
+
+Names follow the Prometheus naming recommendations:
+
+- Use the application prefix `briefing_officer`.
+- Use `_total` for counters.
+- Use labels for dimensions instead of baking dimensions into metric names.
+- Keep each metric to one logical quantity and one unit.
+- Use base units where applicable.
+
+### Gauges
+
+Database-backed gauges:
+
+```text
+briefing_officer_users_total
+briefing_officer_feeds_total{user_id}
+briefing_officer_articles_total{user_id,feed_name}
+briefing_officer_articles_unread_total{user_id,feed_name}
+briefing_officer_articles_read_later_total{user_id,feed_name}
+briefing_officer_articles_starred_total{user_id,feed_name}
+```
+
+Although these names end in `_total`, they are gauges because they describe
+current totals that can decrease when feeds or articles are deleted or when
+article state changes.
+
+### Counters
+
+Runtime counters:
+
+```text
+briefing_officer_article_scrapes_total{user_id,feed_name,status="success|error"}
+briefing_officer_ai_lead_generations_total{user_id,feed_name,status="success|error"}
+briefing_officer_ai_summary_generations_total{user_id,feed_name,status="success|error"}
+briefing_officer_language_model_tokens_total{model,direction="input|output"}
+```
+
+Use `status="error"` rather than `fail` or `failure`; it is concise and pairs
+well with `success`. The scrape, AI lead, and AI summary counters describe
+operation outcomes, so both success and error attempts are represented by the
+same metric family.
+
+`briefing_officer_language_model_tokens_total` combines input and output token
+counts in one metric because both labels represent the same logical quantity and
+unit: tokens. The `direction` label differentiates the characteristic of the
+tokens. The name uses `language_model` instead of the `llm` acronym so the
+published metric remains explicit.
+
+## Components
+
+### `src/lib/metrics.ts`
+
+Owns the Prometheus registry, metric definitions, and recording helpers.
+
+Responsibilities:
+
+1. Create a Prometheus registry for runtime counters. Production does not need
+   counter values to survive development hot reloads.
+2. Define all runtime counters with the agreed names and labels.
+3. Expose helper functions:
+   - `recordArticleScrape({ userId, feedName, status })`
+   - `recordAiLeadGeneration({ userId, feedName, status })`
+   - `recordAiSummaryGeneration({ userId, feedName, status })`
+   - `recordLanguageModelTokens({ model, direction, tokens })`
+4. Expose a function to render runtime metrics from the registry.
+5. Keep label values as plain strings and let the Prometheus client handle
+   exposition escaping.
+
+### `src/lib/metricsRepository.ts`
+
+Collects database-backed gauge values at scrape time.
+
+Responsibilities:
+
+1. Count users globally.
+2. Count feeds per user.
+3. Count all articles per user and feed.
+4. Count unread articles per user and feed.
+5. Count read-later articles per user and feed.
+6. Count starred articles per user and feed.
+7. Return rows in a stable order so output is deterministic in tests.
+
+The repository should not use session-scoped dashboard helpers because metrics
+are global operational data.
+
+### `src/lib/metricsFormatter.ts`
+
+Serializes database-backed gauge rows to Prometheus text exposition.
+
+Responsibilities:
+
+1. Emit `HELP` and `TYPE` lines for every gauge metric.
+2. Escape label names and values according to Prometheus text exposition rules.
+3. Keep rendering deterministic.
+
+The runtime counters can use the Prometheus client formatter directly; the gauge
+formatter covers scrape-time DB values that are not stored in the runtime
+registry.
+
+### `src/app/api/metrics/route.ts`
+
+Handles HTTP behavior only:
+
+1. Check whether metrics are enabled by reading `METRICS_TOKEN`.
+2. Validate `Authorization: Bearer <token>`.
+3. Collect DB gauges.
+4. Render gauges plus runtime counters into one response body.
+5. Return the correct status and content type.
+
+## Instrumentation Points
+
+### Feed refresh and article scraping
+
+`refreshFeed` already knows the feed id, feed title, user id, and newly created
+articles. Increment `briefing_officer_article_scrapes_total` once for each
+article scrape attempt:
+
+- `status="success"` after `scrapeArticle` succeeds.
+- `status="error"` when `scrapeArticle` throws.
+
+### AI lead generation
+
+`generateAiLead` loads the article and knows the user id, feed id, and model.
+Include feed title in the article query or load it separately. Increment
+`briefing_officer_ai_lead_generations_total`:
+
+- `status="success"` after the lead is saved.
+- `status="error"` when generation or persistence throws after the article and
+  feed context is known.
+
+Also record input and output tokens through
+`briefing_officer_language_model_tokens_total` after successful generation.
+
+### AI summary generation
+
+`streamAiSummary` knows the user id, article, feed, and model. Increment
+`briefing_officer_ai_summary_generations_total`:
+
+- `status="success"` after the stream completes and usage is available.
+- `status="error"` when the streaming task throws after article and feed context
+  is known.
+
+Also record input and output tokens through
+`briefing_officer_language_model_tokens_total` after successful generation.
+
+## Error Handling
+
+- Metrics recording must not break product workflows. Recording helper failures
+  should be avoided by construction and should not throw for normal label/value
+  input.
+- Existing scrape and AI errors should continue to follow current application
+  behavior.
+- `/api/metrics` should fail closed: no token means no endpoint, and scrape-time
+  database errors return `503`.
+
+## Cardinality and Privacy
+
+The agreed labels include `user_id` and `feed_name`. These are useful for
+operational breakdowns, but they are high-cardinality and can expose identifiers
+to Prometheus. This is intentional for the first version and should be called
+out in release notes or deployment docs.
+
+## Testing
+
+Use Vitest with test-first implementation.
+
+Unit tests:
+
+1. Metrics helpers increment counters with the expected names and labels.
+2. Gauge formatter emits valid `HELP`, `TYPE`, labels, and values.
+3. Label values are escaped correctly.
+
+Integration or route tests:
+
+1. `GET /api/metrics` returns `404` when `METRICS_TOKEN` is missing.
+2. `GET /api/metrics` returns `401` for missing or wrong bearer token.
+3. `GET /api/metrics` returns Prometheus text and content type for a valid
+   token.
+4. Gauge values reflect seeded feed and article state.
+
+Service tests:
+
+1. Article scrape success and error paths increment the scrape counter.
+2. AI lead success and error paths increment the lead counter.
+3. AI summary success and error paths increment the summary counter.
+4. Token usage records input and output token counters by model.
+
+## Out of Scope
+
+- Creating or managing `ServiceMonitor` manifests in the Helm chart.
+- Adding process, Node.js, HTTP request, or default runtime metrics.
+- Persisting runtime counters to SQLite.
+- Adding per-request metrics middleware.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,17 @@ const __dirname = path.dirname(__filename);
 
 export default defineConfig([
   {
+    ignores: [
+      ".next/**",
+      "blob-report/**",
+      "coverage/**",
+      "node_modules/**",
+      "out/**",
+      "playwright-report/**",
+      "test-results/**",
+    ],
+  },
+  {
     extends: [...nextCoreWebVitals],
   },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "markdown-to-jsx": "^7.7.17",
         "next": "16.2.7",
         "pino": "^10.3.1",
+        "prom-client": "^15.1.3",
         "quick-lru": "^7.3.0",
         "radix-ui": "^1.4.3",
         "react": "19.2.7",
@@ -6112,6 +6113,12 @@
         }
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -10641,6 +10648,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -12105,6 +12125,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/thread-stream": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "markdown-to-jsx": "^7.7.17",
     "next": "16.2.7",
     "pino": "^10.3.1",
+    "prom-client": "^15.1.3",
     "quick-lru": "^7.3.0",
     "radix-ui": "^1.4.3",
     "react": "19.2.7",

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { getMetricsText } from "@/lib/metrics";
+import { formatGaugeMetrics } from "@/lib/metricsFormatter";
+import { collectGaugeMetrics } from "@/lib/metricsRepository";
+
+const contentType = "text/plain; version=0.0.4; charset=utf-8";
+
+export const GET = async (request: Request) => {
+  const token = process.env.METRICS_TOKEN;
+
+  if (!token) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  if (request.headers.get("authorization") !== `Bearer ${token}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  try {
+    const [gaugeMetrics, runtimeMetrics] = await Promise.all([
+      collectGaugeMetrics(),
+      getMetricsText(),
+    ]);
+
+    return new Response(
+      `${formatGaugeMetrics(gaugeMetrics)}\n${runtimeMetrics}`,
+      {
+        status: 200,
+        headers: {
+          "content-type": contentType,
+        },
+      },
+    );
+  } catch {
+    return new Response("Service Unavailable", { status: 503 });
+  }
+};

--- a/src/lib/ai/services/leadService.ts
+++ b/src/lib/ai/services/leadService.ts
@@ -3,6 +3,7 @@
 import { buildLeadPrompt, systemPrompt } from "@/lib/ai/prompts";
 import { getFirstConfiguredLanguageModel } from "@/lib/ai/registry";
 import logger from "@/lib/logger";
+import { recordAiLeadGeneration } from "@/lib/metrics";
 import prisma from "@/lib/prismaClient";
 import { generateText } from "ai";
 import { trackTokenUsage } from "./tokenUsageService";
@@ -11,43 +12,67 @@ const model = await getFirstConfiguredLanguageModel();
 
 export const generateAiLead = async (articleId: number) => {
   const article = await prisma.article.findUniqueOrThrow({
-    include: { scrape: true },
+    include: { feed: true, scrape: true },
     where: { id: articleId },
   });
 
-  const lead = await generateText({
-    model,
-    system: systemPrompt,
-    prompt: buildLeadPrompt(article.title, article.scrape?.textContent ?? ""),
-  });
+  try {
+    const lead = await generateText({
+      model,
+      system: systemPrompt,
+      prompt: buildLeadPrompt(article.title, article.scrape?.textContent ?? ""),
+    });
 
-  await prisma.articleLead.upsert({
-    where: { articleId },
-    create: {
-      articleId,
-      text: lead.text,
-    },
-    update: {
-      text: lead.text,
-    },
-  });
+    await prisma.articleLead.upsert({
+      where: { articleId },
+      create: {
+        articleId,
+        text: lead.text,
+      },
+      update: {
+        text: lead.text,
+      },
+    });
 
-  await trackTokenUsage(
-    article.userId,
-    model.modelId,
-    lead.totalUsage.inputTokens ?? 0,
-    lead.totalUsage.outputTokens ?? 0,
-  );
+    await trackTokenUsage(
+      article.userId,
+      model.modelId,
+      lead.totalUsage.inputTokens ?? 0,
+      lead.totalUsage.outputTokens ?? 0,
+    );
 
-  logger.info(
-    {
-      articleId,
-      feedId: article.feedId,
-      model: model.modelId,
-      tokenUsage: lead.totalUsage,
-    },
-    "AI lead generated.",
-  );
+    logger.info(
+      {
+        articleId,
+        feedId: article.feedId,
+        model: model.modelId,
+        tokenUsage: lead.totalUsage,
+      },
+      "AI lead generated.",
+    );
 
-  return lead.text;
+    try {
+      recordAiLeadGeneration({
+        userId: article.userId,
+        feedName: article.feed.title,
+        status: "success",
+      });
+    } catch {
+      // Metrics failures must never break lead generation.
+    }
+
+    return lead.text;
+  } catch (error) {
+    try {
+      recordAiLeadGeneration({
+        userId: article.userId,
+        feedName: article.feed.title,
+        status: "error",
+      });
+    } catch {
+      // Metrics failures must never hide the original failure.
+    }
+
+    throw error;
+  }
 };

--- a/src/lib/ai/services/summaryService.ts
+++ b/src/lib/ai/services/summaryService.ts
@@ -60,16 +60,6 @@ export const streamAiSummary = async (articleId: number) => {
       finishStream();
 
       try {
-        recordAiSummaryGeneration({
-          userId,
-          feedName: article.feed.title,
-          status: "success",
-        });
-      } catch {
-        // Metrics failures must never break summary generation.
-      }
-
-      try {
         const tokenUsage = await totalUsage;
 
         logger.info(
@@ -82,15 +72,21 @@ export const streamAiSummary = async (articleId: number) => {
           "AI summary generated.",
         );
 
+        await trackTokenUsage(
+          userId,
+          model.modelId,
+          tokenUsage.inputTokens ?? 0,
+          tokenUsage.outputTokens ?? 0,
+        );
+
         try {
-          await trackTokenUsage(
+          recordAiSummaryGeneration({
             userId,
-            model.modelId,
-            tokenUsage.inputTokens ?? 0,
-            tokenUsage.outputTokens ?? 0,
-          );
+            feedName: article.feed.title,
+            status: "success",
+          });
         } catch {
-          // Token usage tracking must never break summary generation.
+          // Metrics failures must never break summary generation.
         }
       } catch (error) {
         logger.error(

--- a/src/lib/ai/services/summaryService.ts
+++ b/src/lib/ai/services/summaryService.ts
@@ -3,6 +3,7 @@
 import { buildSummaryPrompt, systemPrompt } from "@/lib/ai/prompts";
 import { getFirstConfiguredLanguageModel } from "@/lib/ai/registry";
 import logger from "@/lib/logger";
+import { recordAiSummaryGeneration } from "@/lib/metrics";
 import prisma from "@/lib/prismaClient";
 import { getUserId } from "@/lib/repository/userRepository";
 import { createStreamableValue } from "@ai-sdk/rsc";
@@ -16,45 +17,119 @@ export const streamAiSummary = async (articleId: number) => {
 
   const article = await prisma.article.findUniqueOrThrow({
     where: { id: articleId, userId },
-    include: { scrape: true },
+    include: {
+      feed: {
+        select: {
+          title: true,
+        },
+      },
+      scrape: true,
+    },
   });
 
   const stream = createStreamableValue("");
 
   void (async () => {
-    const { textStream, totalUsage } = streamText({
-      model,
-      system: systemPrompt,
-      prompt: buildSummaryPrompt(
-        article.title,
-        article.scrape?.textContent ?? "",
-      ),
-    });
+    let finished = false;
 
-    for await (const delta of textStream) {
-      stream.update(delta);
+    const finishStream = () => {
+      if (finished) {
+        return;
+      }
+
+      finished = true;
+      stream.done();
+    };
+
+    try {
+      const { textStream, totalUsage } = await Promise.resolve(
+        streamText({
+          model,
+          system: systemPrompt,
+          prompt: buildSummaryPrompt(
+            article.title,
+            article.scrape?.textContent ?? "",
+          ),
+        }),
+      );
+
+      for await (const delta of textStream) {
+        stream.update(delta);
+      }
+
+      finishStream();
+
+      try {
+        recordAiSummaryGeneration({
+          userId,
+          feedName: article.feed.title,
+          status: "success",
+        });
+      } catch {
+        // Metrics failures must never break summary generation.
+      }
+
+      try {
+        const tokenUsage = await totalUsage;
+
+        logger.info(
+          {
+            articleId,
+            feedId: article.feedId,
+            model: model.modelId,
+            tokenUsage,
+          },
+          "AI summary generated.",
+        );
+
+        try {
+          await trackTokenUsage(
+            userId,
+            model.modelId,
+            tokenUsage.inputTokens ?? 0,
+            tokenUsage.outputTokens ?? 0,
+          );
+        } catch {
+          // Token usage tracking must never break summary generation.
+        }
+      } catch (error) {
+        logger.error(
+          {
+            articleId,
+            feedId: article.feedId,
+            model: model.modelId,
+            error,
+          },
+          "AI summary token usage bookkeeping failed.",
+        );
+      }
+    } catch (error) {
+      try {
+        recordAiSummaryGeneration({
+          userId,
+          feedName: article.feed.title,
+          status: "error",
+        });
+      } catch {
+        // Metrics failures must never hide the original failure.
+      }
+
+      try {
+        finishStream();
+      } catch {
+        // Stream completion must never break product workflows.
+      }
+
+      logger.error(
+        {
+          articleId,
+          feedId: article.feedId,
+          model: model.modelId,
+          error,
+        },
+        "AI summary generation failed.",
+      );
     }
-
-    stream.done();
-
-    const tokenUsage = await totalUsage;
-
-    logger.info(
-      {
-        articleId,
-        feedId: article.feedId,
-        model: model.modelId,
-        tokenUsage,
-      },
-      "AI summary generated.",
-    );
-
-    await trackTokenUsage(
-      userId,
-      model.modelId,
-      tokenUsage.inputTokens ?? 0,
-      tokenUsage.outputTokens ?? 0,
-    );
   })();
 
   return { output: stream.value };

--- a/src/lib/ai/services/tokenUsageService.ts
+++ b/src/lib/ai/services/tokenUsageService.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { recordLanguageModelTokens } from "@/lib/metrics";
 import prisma from "@/lib/prismaClient";
 
 export const trackTokenUsage = async (
@@ -30,4 +31,19 @@ export const trackTokenUsage = async (
       outputTokens: { increment: outputTokens },
     },
   });
+
+  try {
+    recordLanguageModelTokens({
+      model,
+      direction: "input",
+      tokens: inputTokens,
+    });
+    recordLanguageModelTokens({
+      model,
+      direction: "output",
+      tokens: outputTokens,
+    });
+  } catch {
+    // Metrics failures must never break persistence.
+  }
 };

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,124 @@
+import { Counter, Registry } from "prom-client";
+
+export type OperationStatus = "success" | "error";
+export type TokenDirection = "input" | "output";
+
+type ArticleScrapeEvent = {
+  userId: string;
+  feedName: string;
+  status: OperationStatus;
+};
+
+type AiGenerationEvent = ArticleScrapeEvent;
+
+type LanguageModelTokenEvent = {
+  model: string;
+  direction: TokenDirection;
+  tokens: number;
+};
+
+let registry: Registry;
+let articleScrapesTotal: Counter<string>;
+let aiLeadGenerationsTotal: Counter<string>;
+let aiSummaryGenerationsTotal: Counter<string>;
+let languageModelTokensTotal: Counter<string>;
+
+const createRegistry = () => {
+  const nextRegistry = new Registry();
+
+  const nextArticleScrapesTotal = new Counter({
+    name: "briefing_officer_article_scrapes_total",
+    help: "Total article scrape attempts.",
+    labelNames: ["user_id", "feed_name", "status"],
+    registers: [nextRegistry],
+  });
+
+  const nextAiLeadGenerationsTotal = new Counter({
+    name: "briefing_officer_ai_lead_generations_total",
+    help: "Total AI lead generation attempts.",
+    labelNames: ["user_id", "feed_name", "status"],
+    registers: [nextRegistry],
+  });
+
+  const nextAiSummaryGenerationsTotal = new Counter({
+    name: "briefing_officer_ai_summary_generations_total",
+    help: "Total AI summary generation attempts.",
+    labelNames: ["user_id", "feed_name", "status"],
+    registers: [nextRegistry],
+  });
+
+  const nextLanguageModelTokensTotal = new Counter({
+    name: "briefing_officer_language_model_tokens_total",
+    help: "Total language model tokens.",
+    labelNames: ["model", "direction"],
+    registers: [nextRegistry],
+  });
+
+  registry = nextRegistry;
+  articleScrapesTotal = nextArticleScrapesTotal;
+  aiLeadGenerationsTotal = nextAiLeadGenerationsTotal;
+  aiSummaryGenerationsTotal = nextAiSummaryGenerationsTotal;
+  languageModelTokensTotal = nextLanguageModelTokensTotal;
+};
+
+createRegistry();
+
+export const resetMetricsForTests = () => {
+  createRegistry();
+};
+
+export const recordArticleScrape = ({
+  userId,
+  feedName,
+  status,
+}: ArticleScrapeEvent) => {
+  articleScrapesTotal.inc({
+    user_id: userId,
+    feed_name: feedName,
+    status,
+  });
+};
+
+export const recordAiLeadGeneration = ({
+  userId,
+  feedName,
+  status,
+}: AiGenerationEvent) => {
+  aiLeadGenerationsTotal.inc({
+    user_id: userId,
+    feed_name: feedName,
+    status,
+  });
+};
+
+export const recordAiSummaryGeneration = ({
+  userId,
+  feedName,
+  status,
+}: AiGenerationEvent) => {
+  aiSummaryGenerationsTotal.inc({
+    user_id: userId,
+    feed_name: feedName,
+    status,
+  });
+};
+
+export const recordLanguageModelTokens = ({
+  model,
+  direction,
+  tokens,
+}: LanguageModelTokenEvent) => {
+  if (tokens <= 0) {
+    return;
+  }
+
+  languageModelTokensTotal.inc(
+    {
+      model,
+      direction,
+    },
+    tokens,
+  );
+};
+
+export const getMetricsText = async () => registry.metrics();

--- a/src/lib/metricsFormatter.ts
+++ b/src/lib/metricsFormatter.ts
@@ -1,0 +1,91 @@
+export type GaugeMetrics = {
+  usersTotal: number;
+  feeds: Array<{
+    userId: string;
+    count: number;
+  }>;
+  articles: Array<{
+    userId: string;
+    feedName: string;
+    total: number;
+    unread: number;
+    readLater: number;
+    starred: number;
+  }>;
+};
+
+type GaugeDefinition = {
+  help: string;
+  name: string;
+  rows: string[];
+};
+
+const escapeLabelValue = (value: string) =>
+  value.replaceAll("\\", "\\\\").replaceAll("\n", "\\n").replaceAll('"', '\\"');
+
+const formatLabels = (labels: Record<string, string>) => {
+  const entries = Object.entries(labels);
+
+  if (entries.length === 0) {
+    return "";
+  }
+
+  return `{${entries
+    .map(([key, value]) => `${key}="${escapeLabelValue(value)}"`)
+    .join(",")}}`;
+};
+
+const formatGauge = ({ help, name, rows }: GaugeDefinition) =>
+  [`# HELP ${name} ${help}`, `# TYPE ${name} gauge`, ...rows].join("\n");
+
+export const formatGaugeMetrics = (metrics: GaugeMetrics) => {
+  const sections = [
+    formatGauge({
+      help: "Total users.",
+      name: "briefing_officer_users_total",
+      rows: [`briefing_officer_users_total ${metrics.usersTotal}`],
+    }),
+    formatGauge({
+      help: "Total feeds per user.",
+      name: "briefing_officer_feeds_total",
+      rows: metrics.feeds.map(
+        ({ userId, count }) =>
+          `briefing_officer_feeds_total${formatLabels({ user_id: userId })} ${count}`,
+      ),
+    }),
+    formatGauge({
+      help: "Total articles per feed.",
+      name: "briefing_officer_articles_total",
+      rows: metrics.articles.map(
+        ({ userId, feedName, total }) =>
+          `briefing_officer_articles_total${formatLabels({ user_id: userId, feed_name: feedName })} ${total}`,
+      ),
+    }),
+    formatGauge({
+      help: "Total unread articles per feed.",
+      name: "briefing_officer_articles_unread_total",
+      rows: metrics.articles.map(
+        ({ userId, feedName, unread }) =>
+          `briefing_officer_articles_unread_total${formatLabels({ user_id: userId, feed_name: feedName })} ${unread}`,
+      ),
+    }),
+    formatGauge({
+      help: "Total read later articles per feed.",
+      name: "briefing_officer_articles_read_later_total",
+      rows: metrics.articles.map(
+        ({ userId, feedName, readLater }) =>
+          `briefing_officer_articles_read_later_total${formatLabels({ user_id: userId, feed_name: feedName })} ${readLater}`,
+      ),
+    }),
+    formatGauge({
+      help: "Total starred articles per feed.",
+      name: "briefing_officer_articles_starred_total",
+      rows: metrics.articles.map(
+        ({ userId, feedName, starred }) =>
+          `briefing_officer_articles_starred_total${formatLabels({ user_id: userId, feed_name: feedName })} ${starred}`,
+      ),
+    }),
+  ];
+
+  return `${sections.join("\n")}\n`;
+};

--- a/src/lib/metricsRepository.ts
+++ b/src/lib/metricsRepository.ts
@@ -1,0 +1,150 @@
+"use server";
+
+import { type GaugeMetrics } from "@/lib/metricsFormatter";
+import prisma from "@/lib/prismaClient";
+
+export const collectGaugeMetrics = async (): Promise<GaugeMetrics> => {
+  const [
+    usersTotal,
+    feeds,
+    feedRows,
+    totalByFeed,
+    unreadByFeed,
+    readLaterByFeed,
+    starredByFeed,
+  ] = await Promise.all([
+    prisma.user.count(),
+    prisma.feed.groupBy({
+      by: ["userId"],
+      _count: {
+        _all: true,
+      },
+      orderBy: {
+        userId: "asc",
+      },
+    }),
+    prisma.feed.findMany({
+      select: {
+        id: true,
+        title: true,
+        userId: true,
+      },
+      orderBy: [{ userId: "asc" }, { title: "asc" }, { id: "asc" }],
+    }),
+    prisma.article.groupBy({
+      by: ["feedId"],
+      _count: {
+        _all: true,
+      },
+    }),
+    prisma.article.groupBy({
+      by: ["feedId"],
+      _count: {
+        _all: true,
+      },
+      where: {
+        readAt: null,
+      },
+    }),
+    prisma.article.groupBy({
+      by: ["feedId"],
+      _count: {
+        _all: true,
+      },
+      where: {
+        readLater: true,
+      },
+    }),
+    prisma.article.groupBy({
+      by: ["feedId"],
+      _count: {
+        _all: true,
+      },
+      where: {
+        starred: true,
+      },
+    }),
+  ]);
+
+  const aggregatedArticles = new Map<
+    string,
+    {
+      feedName: string;
+      readLater: number;
+      starred: number;
+      total: number;
+      unread: number;
+      userId: string;
+    }
+  >();
+  const feedKeyById = new Map<number, string>();
+
+  const countByFeedId = (
+    groupedCounts: Array<{
+      _count: {
+        _all: number;
+      };
+      feedId: number;
+    }>,
+  ) =>
+    new Map(groupedCounts.map(({ feedId, _count }) => [feedId, _count._all]));
+
+  const totalByFeedId = countByFeedId(totalByFeed);
+  const unreadByFeedId = countByFeedId(unreadByFeed);
+  const readLaterByFeedId = countByFeedId(readLaterByFeed);
+  const starredByFeedId = countByFeedId(starredByFeed);
+
+  for (const feed of feedRows) {
+    const key = `${feed.userId}\u0000${feed.title}`;
+    feedKeyById.set(feed.id, key);
+
+    if (aggregatedArticles.has(key)) {
+      continue;
+    }
+
+    aggregatedArticles.set(key, {
+      userId: feed.userId,
+      feedName: feed.title,
+      total: 0,
+      unread: 0,
+      readLater: 0,
+      starred: 0,
+    });
+  }
+
+  for (const feed of feedRows) {
+    const key = feedKeyById.get(feed.id);
+
+    if (!key) {
+      continue;
+    }
+
+    const current = aggregatedArticles.get(key);
+
+    if (!current) {
+      continue;
+    }
+
+    current.total += totalByFeedId.get(feed.id) ?? 0;
+    current.unread += unreadByFeedId.get(feed.id) ?? 0;
+    current.readLater += readLaterByFeedId.get(feed.id) ?? 0;
+    current.starred += starredByFeedId.get(feed.id) ?? 0;
+  }
+
+  return {
+    usersTotal,
+    feeds: feeds.map(({ userId, _count }) => ({
+      userId,
+      count: _count._all,
+    })),
+    articles: Array.from(aggregatedArticles.values()).sort((left, right) => {
+      const userComparison = left.userId.localeCompare(right.userId);
+
+      if (userComparison !== 0) {
+        return userComparison;
+      }
+
+      return left.feedName.localeCompare(right.feedName);
+    }),
+  };
+};

--- a/src/lib/repository/feedRepository.ts
+++ b/src/lib/repository/feedRepository.ts
@@ -2,6 +2,7 @@
 
 import { generateAiLead } from "@/lib/ai/services/leadService";
 import logger from "@/lib/logger";
+import { recordArticleScrape } from "@/lib/metrics";
 import prisma from "@/lib/prismaClient";
 import { filterFeedItemsByTitle } from "@/lib/repository/feedFilter";
 import { CategorySchema, FeedSchema } from "@/lib/repository/feedSchema";
@@ -11,6 +12,16 @@ import { Article, Feed } from "@prisma/client";
 import { parseFeed } from "htmlparser2";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
+
+const safeRecordArticleScrape = (
+  event: Parameters<typeof recordArticleScrape>[0],
+) => {
+  try {
+    recordArticleScrape(event);
+  } catch {
+    // Metrics must never block feed refresh workflows.
+  }
+};
 
 export const createFeed = async (feed: FeedSchema) => {
   const fetchedFeed = await fetch(feed.link).then((res) => res.text());
@@ -46,10 +57,20 @@ export const deleteFeed = async (feedId: number) => {
   redirect("/");
 };
 
-const processArticle = async (article: Article) => {
+const processArticle = async (article: Article, feedName: string) => {
   try {
     await scrapeArticle(article.id, article.link);
+    safeRecordArticleScrape({
+      userId: article.userId,
+      feedName,
+      status: "success",
+    });
   } catch (error) {
+    safeRecordArticleScrape({
+      userId: article.userId,
+      feedName,
+      status: "error",
+    });
     logger.error(
       { article: { id: article.id, title: article.title, link: article.link } },
       "Failed to scrape article.",
@@ -119,7 +140,7 @@ export const refreshFeed = async (feedId: number) => {
     .filter((article) => !existingLinks.has(article.link));
 
   const processedArticles = createdArticles.map((article) =>
-    processArticle(article),
+    processArticle(article, feed.title),
   );
   await Promise.allSettled(processedArticles);
 

--- a/tests/integration/feedRepository.test.ts
+++ b/tests/integration/feedRepository.test.ts
@@ -14,8 +14,20 @@ vi.mock("@/lib/scraper", () => ({
 vi.mock("@/lib/ai/services/leadService", () => ({
   generateAiLead: vi.fn(),
 }));
+vi.mock("@/lib/metrics", () => ({
+  recordArticleScrape: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
 
 import { generateAiLead } from "@/lib/ai/services/leadService";
+import logger from "@/lib/logger";
+import { recordArticleScrape } from "@/lib/metrics";
 import {
   createCategory as createCategoryAction,
   createFeed as createFeedAction,
@@ -48,6 +60,8 @@ beforeEach(async () => {
   vi.mocked(scrapeArticle).mockResolvedValue(undefined as never);
   vi.mocked(generateAiLead).mockResolvedValue(undefined as never);
   vi.mocked(scrapeFeed).mockResolvedValue([]);
+  vi.mocked(recordArticleScrape).mockReset();
+  vi.mocked(logger.error).mockClear();
 });
 
 describe("feedRepository.refreshFeed", () => {
@@ -67,6 +81,76 @@ describe("feedRepository.refreshFeed", () => {
     expect(refreshed.lastFetched.getTime()).toBeGreaterThan(
       new Date(0).getTime(),
     );
+  });
+
+  it("records a successful article scrape", async () => {
+    const feed = await createFeed({ userId, title: "Tech Feed" });
+    vi.mocked(scrapeFeed).mockResolvedValue([
+      feedItem("Article", "https://example.com/1"),
+    ]);
+
+    await refreshFeed(feed.id);
+
+    expect(vi.mocked(recordArticleScrape)).toHaveBeenCalledWith({
+      userId,
+      feedName: "Tech Feed",
+      status: "success",
+    });
+  });
+
+  it("continues AI lead generation when successful scrape metric recording fails", async () => {
+    const feed = await createFeed({ userId, title: "Tech Feed" });
+    vi.mocked(scrapeFeed).mockResolvedValue([
+      feedItem("Article", "https://example.com/1"),
+    ]);
+    vi.mocked(recordArticleScrape).mockImplementationOnce(() => {
+      throw new Error("metric failed");
+    });
+
+    await refreshFeed(feed.id);
+
+    expect(vi.mocked(generateAiLead)).toHaveBeenCalledWith(expect.any(Number));
+    expect(vi.mocked(recordArticleScrape)).not.toHaveBeenCalledWith({
+      userId,
+      feedName: "Tech Feed",
+      status: "error",
+    });
+    expect(vi.mocked(logger.error)).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "Failed to scrape article.",
+    );
+  });
+
+  it("records a failed article scrape and still generates an AI lead", async () => {
+    const feed = await createFeed({ userId, title: "Tech Feed" });
+    vi.mocked(scrapeFeed).mockResolvedValue([
+      feedItem("Article", "https://example.com/1"),
+    ]);
+    vi.mocked(scrapeArticle).mockRejectedValueOnce(new Error("scrape failed"));
+
+    await refreshFeed(feed.id);
+
+    expect(vi.mocked(recordArticleScrape)).toHaveBeenCalledWith({
+      userId,
+      feedName: "Tech Feed",
+      status: "error",
+    });
+    expect(vi.mocked(generateAiLead)).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it("continues AI lead generation when failed scrape metric recording fails", async () => {
+    const feed = await createFeed({ userId, title: "Tech Feed" });
+    vi.mocked(scrapeFeed).mockResolvedValue([
+      feedItem("Article", "https://example.com/1"),
+    ]);
+    vi.mocked(scrapeArticle).mockRejectedValueOnce(new Error("scrape failed"));
+    vi.mocked(recordArticleScrape).mockImplementationOnce(() => {
+      throw new Error("metric failed");
+    });
+
+    await refreshFeed(feed.id);
+
+    expect(vi.mocked(generateAiLead)).toHaveBeenCalledWith(expect.any(Number));
   });
 
   it("updates commentsLink on an existing article when the feed is refreshed", async () => {

--- a/tests/integration/leadService.test.ts
+++ b/tests/integration/leadService.test.ts
@@ -8,6 +8,10 @@ vi.mock("@/lib/ai/registry", () => ({
     modelId: "test-model",
   })),
 }));
+vi.mock("@/lib/metrics", () => ({
+  recordAiLeadGeneration: vi.fn(),
+  recordLanguageModelTokens: vi.fn(),
+}));
 vi.mock("ai", () => ({
   generateText: vi.fn(async () => ({
     text: "Generated lead.",
@@ -15,12 +19,16 @@ vi.mock("ai", () => ({
   })),
 }));
 
+import { buildLeadPrompt } from "@/lib/ai/prompts";
 import { generateAiLead } from "@/lib/ai/services/leadService";
+import { recordAiLeadGeneration } from "@/lib/metrics";
+import { generateText } from "ai";
 
 let userId: string;
 let feedId: number;
 
 beforeEach(async () => {
+  vi.clearAllMocks();
   userId = (await createUser()).id;
   feedId = (await createFeed({ userId })).id;
 });
@@ -37,6 +45,54 @@ describe("generateAiLead", () => {
     });
     expect(lead.text).toBe("Generated lead.");
 
+    const usage = await prisma.tokenUsage.findFirstOrThrow({
+      where: { userId },
+    });
+    expect(usage.inputTokens).toBe(7);
+    expect(usage.outputTokens).toBe(3);
+    expect(vi.mocked(recordAiLeadGeneration)).toHaveBeenCalledWith({
+      userId,
+      feedName: "Test Feed",
+      status: "success",
+    });
+    expect(vi.mocked(generateText)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: buildLeadPrompt(article.title, ""),
+      }),
+    );
+  });
+
+  it("records a failed generation when text generation rejects", async () => {
+    const article = await createArticle({ userId, feedId });
+    vi.mocked(generateText).mockRejectedValueOnce(
+      new Error("generation failed"),
+    );
+
+    await expect(generateAiLead(article.id)).rejects.toThrow(
+      "generation failed",
+    );
+
+    expect(vi.mocked(recordAiLeadGeneration)).toHaveBeenCalledWith({
+      userId,
+      feedName: "Test Feed",
+      status: "error",
+    });
+  });
+
+  it("still returns the generated lead when success metrics recording fails", async () => {
+    const article = await createArticle({ userId, feedId });
+    vi.mocked(recordAiLeadGeneration).mockImplementationOnce(() => {
+      throw new Error("metric failed");
+    });
+
+    const result = await generateAiLead(article.id);
+
+    expect(result).toBe("Generated lead.");
+    expect(vi.mocked(generateText)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.not.stringContaining("Test Feed"),
+      }),
+    );
     const usage = await prisma.tokenUsage.findFirstOrThrow({
       where: { userId },
     });

--- a/tests/integration/metricsRepository.test.ts
+++ b/tests/integration/metricsRepository.test.ts
@@ -1,0 +1,74 @@
+import { collectGaugeMetrics } from "@/lib/metricsRepository";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetDb } from "../helpers/db";
+import { createArticle, createFeed, createUser } from "../helpers/factories";
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("metricsRepository", () => {
+  it("collects gauge metrics for users, feeds, and duplicate feed names", async () => {
+    const user = await createUser();
+    const firstFeed = await createFeed({ userId: user.id, title: "Tech Feed" });
+    const secondFeed = await createFeed({
+      userId: user.id,
+      title: "Tech Feed",
+    });
+
+    await createArticle({
+      userId: user.id,
+      feedId: firstFeed.id,
+    });
+    await createArticle({
+      userId: user.id,
+      feedId: firstFeed.id,
+      readLater: true,
+    });
+    await createArticle({
+      userId: user.id,
+      feedId: secondFeed.id,
+      readAt: new Date(),
+    });
+    await createArticle({
+      userId: user.id,
+      feedId: secondFeed.id,
+      starred: true,
+    });
+
+    await expect(collectGaugeMetrics()).resolves.toEqual({
+      usersTotal: 1,
+      feeds: [{ userId: user.id, count: 2 }],
+      articles: [
+        {
+          userId: user.id,
+          feedName: "Tech Feed",
+          total: 4,
+          unread: 3,
+          readLater: 1,
+          starred: 1,
+        },
+      ],
+    });
+  });
+
+  it("includes zero-valued article rows for empty feeds", async () => {
+    const user = await createUser();
+    await createFeed({ userId: user.id, title: "Empty Feed" });
+
+    await expect(collectGaugeMetrics()).resolves.toEqual({
+      usersTotal: 1,
+      feeds: [{ userId: user.id, count: 1 }],
+      articles: [
+        {
+          userId: user.id,
+          feedName: "Empty Feed",
+          total: 0,
+          unread: 0,
+          readLater: 0,
+          starred: 0,
+        },
+      ],
+    });
+  });
+});

--- a/tests/integration/metricsRoute.test.ts
+++ b/tests/integration/metricsRoute.test.ts
@@ -1,0 +1,76 @@
+import { GET } from "@/app/api/metrics/route";
+import { recordArticleScrape, resetMetricsForTests } from "@/lib/metrics";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetDb } from "../helpers/db";
+import { createFeed, createUser } from "../helpers/factories";
+
+beforeEach(async () => {
+  resetMetricsForTests();
+  delete process.env.METRICS_TOKEN;
+  await resetDb();
+});
+
+describe("metrics route", () => {
+  it("returns 404 when the metrics token is missing", async () => {
+    const response = await GET(new Request("http://localhost/api/metrics"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 401 when auth is missing with a metrics token set", async () => {
+    process.env.METRICS_TOKEN = "secret-token";
+
+    const response = await GET(new Request("http://localhost/api/metrics"));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 401 when auth is wrong with a metrics token set", async () => {
+    process.env.METRICS_TOKEN = "secret-token";
+
+    const response = await GET(
+      new Request("http://localhost/api/metrics", {
+        headers: {
+          Authorization: "Bearer wrong-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns prometheus metrics for a valid bearer token", async () => {
+    process.env.METRICS_TOKEN = "secret-token";
+
+    const user = await createUser();
+    const feed = await createFeed({ userId: user.id, title: "Tech Feed" });
+
+    recordArticleScrape({
+      userId: user.id,
+      feedName: feed.title,
+      status: "success",
+    });
+
+    const response = await GET(
+      new Request("http://localhost/api/metrics", {
+        headers: {
+          Authorization: "Bearer secret-token",
+        },
+      }),
+    );
+
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; version=0.0.4; charset=utf-8",
+    );
+    expect(body).toContain("briefing_officer_users_total 1");
+    expect(body).toContain(
+      `briefing_officer_feeds_total{user_id="${user.id}"} 1`,
+    );
+    expect(body).toContain(
+      `briefing_officer_article_scrapes_total{user_id="${user.id}",feed_name="Tech Feed",status="success"} 1`,
+    );
+  });
+});

--- a/tests/integration/metricsRoute.test.ts
+++ b/tests/integration/metricsRoute.test.ts
@@ -1,13 +1,27 @@
 import { GET } from "@/app/api/metrics/route";
 import { recordArticleScrape, resetMetricsForTests } from "@/lib/metrics";
-import { beforeEach, describe, expect, it } from "vitest";
+import { collectGaugeMetrics } from "@/lib/metricsRepository";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resetDb } from "../helpers/db";
 import { createFeed, createUser } from "../helpers/factories";
+
+vi.mock("@/lib/metricsRepository", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/metricsRepository")>();
+  return {
+    ...actual,
+    collectGaugeMetrics: vi.fn(actual.collectGaugeMetrics),
+  };
+});
 
 beforeEach(async () => {
   resetMetricsForTests();
   delete process.env.METRICS_TOKEN;
   await resetDb();
+  const actual = await vi.importActual<
+    typeof import("@/lib/metricsRepository")
+  >("@/lib/metricsRepository");
+  vi.mocked(collectGaugeMetrics).mockImplementation(actual.collectGaugeMetrics);
 });
 
 describe("metrics route", () => {
@@ -72,5 +86,23 @@ describe("metrics route", () => {
     expect(body).toContain(
       `briefing_officer_article_scrapes_total{user_id="${user.id}",feed_name="Tech Feed",status="success"} 1`,
     );
+  });
+
+  it("returns 503 when metrics collection fails", async () => {
+    process.env.METRICS_TOKEN = "secret-token";
+    vi.mocked(collectGaugeMetrics).mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/metrics", {
+        headers: {
+          Authorization: "Bearer secret-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.text()).resolves.toBe("Service Unavailable");
   });
 });

--- a/tests/integration/summaryService.test.ts
+++ b/tests/integration/summaryService.test.ts
@@ -134,7 +134,7 @@ describe("streamAiSummary", () => {
     expect(lastStream.done).toHaveBeenCalled();
   });
 
-  it("records success when token usage retrieval fails after streaming completes", async () => {
+  it("does not record success when token usage retrieval fails after streaming completes", async () => {
     const article = await createArticle({ userId, feedId, title: "article" });
     vi.mocked(streamText).mockImplementationOnce(() => ({
       textStream: (async function* () {
@@ -146,13 +146,12 @@ describe("streamAiSummary", () => {
 
     await streamAiSummary(article.id);
 
-    await vi.waitFor(() =>
-      expect(vi.mocked(recordAiSummaryGeneration)).toHaveBeenCalledWith({
-        userId,
-        feedName: "Tech Feed",
-        status: "success",
-      }),
-    );
+    await vi.waitFor(() => expect(lastStream.done).toHaveBeenCalled());
+    expect(vi.mocked(recordAiSummaryGeneration)).not.toHaveBeenCalledWith({
+      userId,
+      feedName: "Tech Feed",
+      status: "success",
+    });
     expect(vi.mocked(recordAiSummaryGeneration)).not.toHaveBeenCalledWith({
       userId,
       feedName: "Tech Feed",
@@ -162,7 +161,7 @@ describe("streamAiSummary", () => {
     expect(lastStream.done).toHaveBeenCalled();
   });
 
-  it("records success when token usage tracking fails after streaming completes", async () => {
+  it("does not record success when token usage tracking fails after streaming completes", async () => {
     const article = await createArticle({ userId, feedId, title: "article" });
     vi.mocked(trackTokenUsage).mockRejectedValueOnce(
       new Error("token tracking failed"),
@@ -171,17 +170,42 @@ describe("streamAiSummary", () => {
     await streamAiSummary(article.id);
 
     await vi.waitFor(() =>
-      expect(vi.mocked(recordAiSummaryGeneration)).toHaveBeenCalledWith({
+      expect(vi.mocked(trackTokenUsage)).toHaveBeenCalledWith(
         userId,
-        feedName: "Tech Feed",
-        status: "success",
-      }),
+        "test-model",
+        11,
+        4,
+      ),
     );
+    expect(vi.mocked(recordAiSummaryGeneration)).not.toHaveBeenCalledWith({
+      userId,
+      feedName: "Tech Feed",
+      status: "success",
+    });
     expect(vi.mocked(recordAiSummaryGeneration)).not.toHaveBeenCalledWith({
       userId,
       feedName: "Tech Feed",
       status: "error",
     });
+    expect(lastStream.done).toHaveBeenCalled();
+  });
+
+  it("records success when success metrics fail after token usage is tracked", async () => {
+    const article = await createArticle({ userId, feedId, title: "article" });
+    vi.mocked(recordAiSummaryGeneration).mockImplementationOnce(() => {
+      throw new Error("metric failed");
+    });
+
+    await streamAiSummary(article.id);
+
+    await vi.waitFor(() =>
+      expect(vi.mocked(trackTokenUsage)).toHaveBeenCalledWith(
+        userId,
+        "test-model",
+        11,
+        4,
+      ),
+    );
     expect(lastStream.done).toHaveBeenCalled();
   });
 

--- a/tests/integration/summaryService.test.ts
+++ b/tests/integration/summaryService.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createArticle, createFeed, createUser } from "../helpers/factories";
+
+vi.mock("@/lib/repository/userRepository", () => ({
+  getUserId: vi.fn(),
+}));
+vi.mock("@/lib/ai/registry", () => ({
+  getFirstConfiguredLanguageModel: vi.fn(async () => ({
+    modelId: "test-model",
+  })),
+}));
+vi.mock("@/lib/metrics", () => ({
+  recordAiSummaryGeneration: vi.fn(),
+}));
+vi.mock("@/lib/ai/services/tokenUsageService", () => ({
+  trackTokenUsage: vi.fn(),
+}));
+vi.mock("@ai-sdk/rsc", () => ({
+  createStreamableValue: vi.fn(() => {
+    const value = "stream-value";
+    return {
+      value,
+      update: vi.fn(),
+      done: vi.fn(),
+    };
+  }),
+}));
+vi.mock("ai", () => ({
+  streamText: vi.fn(() => ({
+    textStream: (async function* () {
+      yield "Summary part 1";
+      yield "Summary part 2";
+    })(),
+    totalUsage: { inputTokens: 11, outputTokens: 4 },
+  })),
+}));
+
+import { buildSummaryPrompt } from "@/lib/ai/prompts";
+import { streamAiSummary } from "@/lib/ai/services/summaryService";
+import { trackTokenUsage } from "@/lib/ai/services/tokenUsageService";
+import { recordAiSummaryGeneration } from "@/lib/metrics";
+import { getUserId } from "@/lib/repository/userRepository";
+import { createStreamableValue } from "@ai-sdk/rsc";
+import { streamText } from "ai";
+
+let userId: string;
+let feedId: number;
+let lastStream: {
+  done: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  userId = (await createUser()).id;
+  feedId = (await createFeed({ userId, title: "Tech Feed" })).id;
+  vi.mocked(getUserId).mockResolvedValue(userId);
+  vi.mocked(createStreamableValue).mockImplementation(() => {
+    lastStream = {
+      done: vi.fn(),
+    };
+    return {
+      value: "stream-value",
+      update: vi.fn(),
+      done: lastStream.done,
+    };
+  });
+});
+
+describe("streamAiSummary", () => {
+  it("records success metrics and token usage after streaming", async () => {
+    const article = await createArticle({ userId, feedId, title: "article" });
+
+    const result = await streamAiSummary(article.id);
+
+    expect(result.output).toBe("stream-value");
+    expect(vi.mocked(streamText)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: buildSummaryPrompt(article.title, ""),
+      }),
+    );
+    expect(vi.mocked(streamText).mock.calls[0]?.[0]?.prompt).not.toContain(
+      "Tech Feed",
+    );
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(recordAiSummaryGeneration)).toHaveBeenCalledWith({
+        userId,
+        feedName: "Tech Feed",
+        status: "success",
+      });
+      expect(vi.mocked(trackTokenUsage)).toHaveBeenCalledWith(
+        userId,
+        "test-model",
+        11,
+        4,
+      );
+    });
+  });
+
+  it("records an error when streaming fails", async () => {
+    const article = await createArticle({ userId, feedId, title: "article" });
+    vi.mocked(streamText).mockImplementationOnce(() => {
+      throw new Error("stream failed");
+    });
+
+    await streamAiSummary(article.id);
+
+    await vi.waitFor(() =>
+      expect(vi.mocked(recordAiSummaryGeneration)).toHaveBeenCalledWith({
+        userId,
+        feedName: "Tech Feed",
+        status: "error",
+      }),
+    );
+  });
+
+  it("still tracks token usage and finishes the stream when success metrics fail", async () => {
+    const article = await createArticle({ userId, feedId, title: "article" });
+    vi.mocked(recordAiSummaryGeneration).mockImplementation(() => {
+      throw new Error("metric failed");
+    });
+
+    await streamAiSummary(article.id);
+
+    await vi.waitFor(() =>
+      expect(vi.mocked(trackTokenUsage)).toHaveBeenCalledWith(
+        userId,
+        "test-model",
+        11,
+        4,
+      ),
+    );
+
+    expect(lastStream.done).toHaveBeenCalled();
+  });
+
+  it("records success when token usage retrieval fails after streaming completes", async () => {
+    const article = await createArticle({ userId, feedId, title: "article" });
+    vi.mocked(streamText).mockImplementationOnce(() => ({
+      textStream: (async function* () {
+        yield "Summary part 1";
+        yield "Summary part 2";
+      })(),
+      totalUsage: Promise.reject(new Error("usage failed")),
+    }));
+
+    await streamAiSummary(article.id);
+
+    await vi.waitFor(() =>
+      expect(vi.mocked(recordAiSummaryGeneration)).toHaveBeenCalledWith({
+        userId,
+        feedName: "Tech Feed",
+        status: "success",
+      }),
+    );
+    expect(vi.mocked(recordAiSummaryGeneration)).not.toHaveBeenCalledWith({
+      userId,
+      feedName: "Tech Feed",
+      status: "error",
+    });
+    expect(vi.mocked(trackTokenUsage)).not.toHaveBeenCalled();
+    expect(lastStream.done).toHaveBeenCalled();
+  });
+
+  it("records success when token usage tracking fails after streaming completes", async () => {
+    const article = await createArticle({ userId, feedId, title: "article" });
+    vi.mocked(trackTokenUsage).mockRejectedValueOnce(
+      new Error("token tracking failed"),
+    );
+
+    await streamAiSummary(article.id);
+
+    await vi.waitFor(() =>
+      expect(vi.mocked(recordAiSummaryGeneration)).toHaveBeenCalledWith({
+        userId,
+        feedName: "Tech Feed",
+        status: "success",
+      }),
+    );
+    expect(vi.mocked(recordAiSummaryGeneration)).not.toHaveBeenCalledWith({
+      userId,
+      feedName: "Tech Feed",
+      status: "error",
+    });
+    expect(lastStream.done).toHaveBeenCalled();
+  });
+
+  it("records an error when the text stream throws during iteration", async () => {
+    const article = await createArticle({ userId, feedId, title: "article" });
+    vi.mocked(streamText).mockImplementationOnce(() => ({
+      textStream: (async function* () {
+        yield "Summary part 1";
+        throw new Error("iteration failed");
+      })(),
+      totalUsage: { inputTokens: 11, outputTokens: 4 },
+    }));
+
+    await streamAiSummary(article.id);
+
+    await vi.waitFor(() =>
+      expect(vi.mocked(recordAiSummaryGeneration)).toHaveBeenCalledWith({
+        userId,
+        feedName: "Tech Feed",
+        status: "error",
+      }),
+    );
+    expect(lastStream.done).toHaveBeenCalled();
+  });
+});

--- a/tests/integration/tokenUsageService.test.ts
+++ b/tests/integration/tokenUsageService.test.ts
@@ -1,11 +1,17 @@
+vi.mock("@/lib/metrics", () => ({
+  recordLanguageModelTokens: vi.fn(),
+}));
+
 import { trackTokenUsage } from "@/lib/ai/services/tokenUsageService";
+import { recordLanguageModelTokens } from "@/lib/metrics";
 import prisma from "@/lib/prismaClient";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createUser } from "../helpers/factories";
 
 let userId: string;
 
 beforeEach(async () => {
+  vi.clearAllMocks();
   userId = (await createUser()).id;
 });
 
@@ -18,6 +24,16 @@ describe("trackTokenUsage", () => {
     expect(rows[0].inputTokens).toBe(10);
     expect(rows[0].outputTokens).toBe(5);
     expect(rows[0]).not.toHaveProperty("reasoningTokens");
+    expect(vi.mocked(recordLanguageModelTokens)).toHaveBeenCalledWith({
+      model: "test-model",
+      direction: "input",
+      tokens: 10,
+    });
+    expect(vi.mocked(recordLanguageModelTokens)).toHaveBeenCalledWith({
+      model: "test-model",
+      direction: "output",
+      tokens: 5,
+    });
   });
 
   it("accumulates tokens for the same user/date/model", async () => {
@@ -28,5 +44,17 @@ describe("trackTokenUsage", () => {
     expect(row.inputTokens).toBe(13);
     expect(row.outputTokens).toBe(7);
     expect(row).not.toHaveProperty("reasoningTokens");
+  });
+
+  it("still persists token usage when metrics recording fails", async () => {
+    vi.mocked(recordLanguageModelTokens).mockImplementationOnce(() => {
+      throw new Error("metric failed");
+    });
+
+    await trackTokenUsage(userId, "test-model", 10, 5);
+
+    const row = await prisma.tokenUsage.findFirstOrThrow({ where: { userId } });
+    expect(row.inputTokens).toBe(10);
+    expect(row.outputTokens).toBe(5);
   });
 });

--- a/tests/unit/metrics.test.ts
+++ b/tests/unit/metrics.test.ts
@@ -1,0 +1,100 @@
+import {
+  getMetricsText,
+  recordAiLeadGeneration,
+  recordAiSummaryGeneration,
+  recordArticleScrape,
+  recordLanguageModelTokens,
+  resetMetricsForTests,
+} from "@/lib/metrics";
+import { beforeEach, describe, expect, it } from "vitest";
+
+beforeEach(() => {
+  resetMetricsForTests();
+});
+
+describe("runtime metrics", () => {
+  it("records article scrape counters with success and error labels", async () => {
+    recordArticleScrape({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "success",
+    });
+    recordArticleScrape({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "error",
+    });
+
+    const metrics = await getMetricsText();
+
+    expect(metrics).toContain(
+      "# TYPE briefing_officer_article_scrapes_total counter",
+    );
+    expect(metrics).toContain(
+      'briefing_officer_article_scrapes_total{user_id="user-1",feed_name="Tech Feed",status="success"} 1',
+    );
+    expect(metrics).toContain(
+      'briefing_officer_article_scrapes_total{user_id="user-1",feed_name="Tech Feed",status="error"} 1',
+    );
+  });
+
+  it("clears recorded samples when resetting metrics", async () => {
+    recordArticleScrape({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "success",
+    });
+
+    const beforeReset = await getMetricsText();
+
+    expect(beforeReset).toContain(
+      'briefing_officer_article_scrapes_total{user_id="user-1",feed_name="Tech Feed",status="success"} 1',
+    );
+
+    resetMetricsForTests();
+
+    const afterReset = await getMetricsText();
+
+    expect(afterReset).not.toContain(
+      'briefing_officer_article_scrapes_total{user_id="user-1",feed_name="Tech Feed",status="success"} 1',
+    );
+  });
+
+  it("records ai generation and token counters", async () => {
+    recordAiLeadGeneration({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "success",
+    });
+    recordAiSummaryGeneration({
+      userId: "user-1",
+      feedName: "Tech Feed",
+      status: "error",
+    });
+    recordLanguageModelTokens({
+      model: "test-model",
+      direction: "input",
+      tokens: 7,
+    });
+    recordLanguageModelTokens({
+      model: "test-model",
+      direction: "output",
+      tokens: 3,
+    });
+
+    const metrics = await getMetricsText();
+
+    expect(metrics).toContain(
+      'briefing_officer_ai_lead_generations_total{user_id="user-1",feed_name="Tech Feed",status="success"} 1',
+    );
+    expect(metrics).toContain(
+      'briefing_officer_ai_summary_generations_total{user_id="user-1",feed_name="Tech Feed",status="error"} 1',
+    );
+    expect(metrics).toContain(
+      'briefing_officer_language_model_tokens_total{model="test-model",direction="input"} 7',
+    );
+    expect(metrics).toContain(
+      'briefing_officer_language_model_tokens_total{model="test-model",direction="output"} 3',
+    );
+  });
+});

--- a/tests/unit/metrics.test.ts
+++ b/tests/unit/metrics.test.ts
@@ -6,6 +6,7 @@ import {
   recordLanguageModelTokens,
   resetMetricsForTests,
 } from "@/lib/metrics";
+import { formatGaugeMetrics } from "@/lib/metricsFormatter";
 import { beforeEach, describe, expect, it } from "vitest";
 
 beforeEach(() => {
@@ -13,6 +14,48 @@ beforeEach(() => {
 });
 
 describe("runtime metrics", () => {
+  it("formats gauge metrics with escaped labels", () => {
+    const output = formatGaugeMetrics({
+      usersTotal: 1,
+      feeds: [{ userId: "user-1", count: 2 }],
+      articles: [
+        {
+          userId: "user-1",
+          feedName: 'Tech "Daily"',
+          total: 3,
+          unread: 2,
+          readLater: 1,
+          starred: 1,
+        },
+      ],
+    });
+
+    expect(output).toContain("# TYPE briefing_officer_users_total gauge");
+    expect(output).toBe(
+      [
+        "# HELP briefing_officer_users_total Total users.",
+        "# TYPE briefing_officer_users_total gauge",
+        "briefing_officer_users_total 1",
+        "# HELP briefing_officer_feeds_total Total feeds per user.",
+        "# TYPE briefing_officer_feeds_total gauge",
+        'briefing_officer_feeds_total{user_id="user-1"} 2',
+        "# HELP briefing_officer_articles_total Total articles per feed.",
+        "# TYPE briefing_officer_articles_total gauge",
+        'briefing_officer_articles_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 3',
+        "# HELP briefing_officer_articles_unread_total Total unread articles per feed.",
+        "# TYPE briefing_officer_articles_unread_total gauge",
+        'briefing_officer_articles_unread_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 2',
+        "# HELP briefing_officer_articles_read_later_total Total read later articles per feed.",
+        "# TYPE briefing_officer_articles_read_later_total gauge",
+        'briefing_officer_articles_read_later_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 1',
+        "# HELP briefing_officer_articles_starred_total Total starred articles per feed.",
+        "# TYPE briefing_officer_articles_starred_total gauge",
+        'briefing_officer_articles_starred_total{user_id="user-1",feed_name="Tech \\"Daily\\""} 1',
+        "",
+      ].join("\n"),
+    );
+  });
+
   it("records article scrape counters with success and error labels", async () => {
     recordArticleScrape({
       userId: "user-1",


### PR DESCRIPTION
## Summary
- expose bearer-token protected Prometheus metrics at /api/metrics
- add DB-backed gauge metrics for users, feeds, and article states
- add runtime counters for article scraping, AI generations, and language model token usage
- isolate metrics failures from product workflows and preserve AI prompt behavior

## Checks
- npm run format:check
- npm run lint
- npm run test
- npm run build

Note: build emits existing Better Auth warnings about the local BETTER_AUTH_SECRET quality, but exits successfully.