### PR TITLE
ci: add scheduled cleanup of old GHCR container images

### DIFF
--- a/.github/workflows/cleanup-container-images.yaml
+++ b/.github/workflows/cleanup-container-images.yaml
@@ -1,0 +1,25 @@
+name: Clean Up Old Container Images
+
+on:
+  schedule:
+    - cron: "14 20 * * 0"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: Delete old GHCR image versions
+    runs-on: ubuntu-latest
+    steps:
+      # Requires the "briefing-officer" package's Actions access to grant
+      # this repository the "Admin" role (Package settings > Manage Actions
+      # access), otherwise GITHUB_TOKEN cannot delete package versions.
+      - name: Delete untagged and non-kept image versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: "briefing-officer"
+          package-type: "container"
+          min-versions-to-keep: 0
+          ignore-versions: '^(latest|unstable|\d+\.\d+\.\d+)$'


### PR DESCRIPTION
## Summary
- Adds a new workflow that deletes old `briefing-officer` container image versions from GHCR using `actions/delete-package-versions`
- Keeps tags `latest`, `unstable`, and any plain semver tag (`x.y.z`); deletes everything else
- Runs weekly (Sundays at 20:14 UTC) and can be triggered manually via `workflow_dispatch`

## Note
`GITHUB_TOKEN` can only delete package versions if the `briefing-officer` package's **Package settings → Manage Actions access** grants this repository the **Admin** role (the default **Write** role isn't sufficient). Worth checking before relying on the scheduled run.

## Test plan
- [x] Manually trigger the workflow via `workflow_dispatch` and confirm it runs successfully
- [x] Verify `latest`, `unstable`, and semver tags remain in GHCR after the run
- [x] Verify other/stale tags are removed