### PR TITLE
fix: include error details in cron and article processing logs

### DIFF
--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -14,11 +14,23 @@ export const POST = async (request: Request) => {
     return new Response("", { status: 401 });
   }
 
-  refreshFeeds()
-    .then(() => logger.debug("Cron finished successfully."))
-    .catch((error) => logger.error({ error }, "Cron failed."));
+  logger.debug("Cron triggered.");
+  const startedAt = Date.now();
 
-  void deleteArticlesOlderThanXDays(ARTICLE_RETENTION_DAYS);
+  refreshFeeds()
+    .then(() =>
+      logger.info(
+        { durationMs: Date.now() - startedAt },
+        "Cron finished: feeds refreshed.",
+      ),
+    )
+    .catch((error) =>
+      logger.error({ err: error }, "Cron failed: refreshing feeds threw."),
+    );
+
+  deleteArticlesOlderThanXDays(ARTICLE_RETENTION_DAYS).catch((error) =>
+    logger.error({ err: error }, "Cron failed: deleting old articles threw."),
+  );
 
   return new Response("", { status: 200 });
 };

--- a/src/lib/repository/feedRepository.ts
+++ b/src/lib/repository/feedRepository.ts
@@ -51,7 +51,10 @@ const processArticle = async (article: Article) => {
     await scrapeArticle(article.id, article.link);
   } catch (error) {
     logger.error(
-      { article: { id: article.id, title: article.title, link: article.link } },
+      {
+        err: error,
+        article: { id: article.id, title: article.title, link: article.link },
+      },
       "Failed to scrape article.",
     );
   }
@@ -60,7 +63,10 @@ const processArticle = async (article: Article) => {
     await generateAiLead(article.id);
   } catch (error) {
     logger.error(
-      { article: { id: article.id, title: article.title, link: article.link } },
+      {
+        err: error,
+        article: { id: article.id, title: article.title, link: article.link },
+      },
       "Failed to generate AI lead.",
     );
   }


### PR DESCRIPTION
## Problem

`Cron failed.` log lines contained an empty `error` object, making failures impossible to diagnose from pod logs. pino's default serializers only handle `Error` objects passed under the `err` key; under any other key the Error is JSON-serialized directly and its non-enumerable `message`/`stack` properties are dropped, leaving `{}`.

## Changes

- Log caught errors under pino's standard `err` key so type, message, and stack trace appear in the output.
- Split the cron failure paths into distinct messages (`refreshing feeds threw` vs. `deleting old articles threw`); both still match `grep -i "cron failed"`.
- Catch rejections from `deleteArticlesOlderThanXDays` — previously fired with `void` and surfaced only as an unhandled rejection with no context.
- Log the cron trigger at debug level and completion (with `durationMs`) at info level; the success log was debug-level and therefore invisible in production.
- Include the caught error in the `Failed to scrape article.` / `Failed to generate AI lead.` logs in `feedRepository.ts`, which previously logged the article but swallowed the reason.

## Verification

Ran `src/lib/logger.ts` directly: `logger.error({ err: new Error('boom') }, ...)` emits full `type`/`message`/`stack`, while the old `{ error }` form emits `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)