### PR TITLE
perf: enable SQLite WAL mode to prevent writes from blocking page loads

### DIFF
--- a/src/lib/prismaClient.ts
+++ b/src/lib/prismaClient.ts
@@ -1,5 +1,29 @@
 import { PrismaClient } from "@prisma/client";
+import logger from "./logger";
 
 const prisma = new PrismaClient();
+
+// SQLite's default journal mode blocks readers for the duration of every
+// write transaction, so a feed refresh can stall the whole site. Enable
+// Write-Ahead Logging so reads can proceed concurrently with writes.
+//
+// journal_mode is persisted in the database file itself, so setting it once
+// here is enough for the lifetime of the file. busy_timeout is per
+// connection rather than persisted, but this module creates the single
+// PrismaClient used for the whole process, so applying it here covers every
+// query made through it. Both pragmas return a result row in SQLite, so
+// $queryRawUnsafe (not $executeRawUnsafe) is required for both.
+//
+// These are awaited at the top level (rather than fired-and-forgotten) so
+// that every other module, which can only reach `prisma` by importing this
+// one, is guaranteed to wait for the pragmas to take effect first. Without
+// that barrier, a query issued in the same tick as module initialization can
+// race ahead of the WAL switch and run against the pre-WAL connection.
+try {
+  await prisma.$queryRawUnsafe("PRAGMA journal_mode = WAL;");
+  await prisma.$queryRawUnsafe("PRAGMA busy_timeout = 5000;");
+} catch (error) {
+  logger.error({ err: error }, "Failed to configure SQLite pragmas");
+}
 
 export default prisma;


### PR DESCRIPTION
## Summary

- The database currently runs in SQLite's default rollback-journal mode, where a write transaction (e.g. a feed refresh) blocks every reader until it commits. Under load this makes page loads stutter while a refresh is in progress.
- Enable Write-Ahead Logging (`PRAGMA journal_mode = WAL`) so reads can proceed concurrently with writes, and set `PRAGMA busy_timeout = 5000` so a query that does contend with a writer retries for up to 5s instead of immediately failing with "database is locked".
- Both pragmas are applied once, at `PrismaClient` construction in `src/lib/prismaClient.ts`, via a top-level `await` (rather than fire-and-forget) so every other module — which can only reach the client by importing this one — is guaranteed to wait for the pragmas before issuing its own queries.

## Why `$queryRawUnsafe` for both, and why top-level await

- `PRAGMA journal_mode = WAL` and `PRAGMA busy_timeout = 5000` both return a result row in SQLite, so `$queryRawUnsafe` is required for both (`$executeRawUnsafe` fails with "Execute returned results, which is not allowed in SQLite").
- `journal_mode` is persisted in the database file header, so setting it once is enough for the file's lifetime. `busy_timeout` is per connection instead — but since this module creates the single `PrismaClient` used for the whole process, setting it here covers every query made through it.
- Verified empirically that firing the pragmas without an `await` barrier is racy: a query issued in the same tick as module initialization can reach a pre-WAL connection before the WAL switch lands. Awaiting them at the top level closes that race, since ESM propagates the `await` to every importer.

## Verification

- Wrote throwaway-database scripts exercising the pragmas directly against Prisma 6.19.3 + SQLite, confirming: `PRAGMA journal_mode = WAL` returns `[{ journal_mode: 'wal' }]`, WAL persists for later `PrismaClient` instances on the same file, and `busy_timeout` stays consistent under genuine concurrent load.
- Ran `npm run build` end-to-end with a real SQLite database — inspected the resulting file afterwards with the `sqlite3` CLI: `PRAGMA journal_mode;` → `wal`.
- Ran the full integration test suite (`npm run test`) and inspected the per-worker SQLite databases it creates: every worker that actually exercised the app's Prisma singleton ended up in `wal` mode; the one worker whose database was only ever touched by `prisma db push` (a separate CLI process, not the app) correctly stayed in `delete` mode, confirming the pragma is applied by our code path specifically.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)