### PR TITLE
Read-button, dismiss-icon, and SQLite path fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,4 @@ OPENAI_MODEL=gpt-4o
 
 BASE_URL=http://localhost:3000
 CRON_API_TOKEN=change-me-to-something-random-and-secret
-DATABASE_URL=file:../data/database.sqlite
+DATABASE_URL=file:./data/database.sqlite

--- a/src/components/article/toggle-read-button.tsx
+++ b/src/components/article/toggle-read-button.tsx
@@ -5,7 +5,7 @@ import {
   markArticleAsRead,
   unmarkArticleAsRead,
 } from "@/lib/repository/articleRepository";
-import { ArchiveRestoreIcon, Trash2Icon } from "lucide-react";
+import { ArchiveRestoreIcon, CheckIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -59,7 +59,7 @@ const ToggleReadButton = ({
         </>
       ) : (
         <>
-          <Trash2Icon className="size-4" />
+          <CheckIcon className="size-4" />
           Dismiss
         </>
       )}

--- a/src/components/article/visit-button.tsx
+++ b/src/components/article/visit-button.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { Article } from "@/generated/prisma/client";
-import { markArticleAsRead } from "@/lib/repository/articleRepository";
 import { ExternalLink } from "lucide-react";
 import Link from "next/link";
 import React from "react";
@@ -20,12 +19,7 @@ const VisitButton = ({ article, size, className }: VisitButtonProps) => {
       variant="secondary"
       className={className ?? "justify-start text-sm"}
     >
-      <Link
-        href={article.link}
-        onClick={() => markArticleAsRead(article.id)}
-        onAuxClick={() => markArticleAsRead(article.id)}
-        referrerPolicy="no-referrer"
-      >
+      <Link href={article.link} referrerPolicy="no-referrer">
         <ExternalLink className="mr-1 size-4" />
         Read
       </Link>


### PR DESCRIPTION
Bundles the three unpushed commits on `main`.

## Changes
- **feat(article):** stop marking an article as read on visit — marking as read is now handled solely by the Dismiss button (`ToggleReadButton`).
- **fix(db):** resolve the SQLite path relative to the project root.
- **fix(article):** use a checkmark instead of a trash icon on the dismiss button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)