### PR TITLE
refactor(article): rename ToggleReadButton to DismissButton

### DIFF
--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -2,7 +2,7 @@
 
 import AiSummaryButton from "@/components/article/ai-summary-button";
 import CommentsButton from "@/components/article/comments-button";
-import ToggleReadButton from "@/components/article/toggle-read-button";
+import DismissButton from "@/components/article/dismiss-button";
 import ToggleReadLaterButton from "@/components/article/toggle-read-later-button";
 import ToggleStarredButton from "@/components/article/toggle-starred-button";
 import VisitButton from "@/components/article/visit-button";
@@ -44,7 +44,7 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
 
     {/* Mobile: row 2 — full-width labeled buttons */}
     <div className="flex w-full gap-2 md:hidden">
-      <ToggleReadButton
+      <DismissButton
         article={props.article}
         className="flex-1 justify-center text-sm"
         onAfterDismiss={props.onAfterDismiss}
@@ -73,7 +73,7 @@ const ArticleCardActions = (props: ArticleCardActionsProps) => (
       <ToggleReadLaterButton article={props.article} />
       <ToggleStarredButton article={props.article} />
       <CommentsButton article={props.article} />
-      <ToggleReadButton
+      <DismissButton
         article={props.article}
         className="cursor-pointer justify-start text-sm"
         onAfterDismiss={props.onAfterDismiss}

--- a/src/components/article/dismiss-button.tsx
+++ b/src/components/article/dismiss-button.tsx
@@ -9,7 +9,7 @@ import { ArchiveRestoreIcon, CheckIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-const ToggleReadButton = ({
+const DismissButton = ({
   article,
   className,
   onAfterDismiss,
@@ -67,4 +67,4 @@ const ToggleReadButton = ({
   );
 };
 
-export default ToggleReadButton;
+export default DismissButton;

--- a/tests/components/article/dismiss-button.test.tsx
+++ b/tests/components/article/dismiss-button.test.tsx
@@ -1,4 +1,4 @@
-import ToggleReadButton from "@/components/article/toggle-read-button";
+import DismissButton from "@/components/article/dismiss-button";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -18,14 +18,11 @@ const unreadArticle = {
   title: "Test article",
 } as any;
 
-describe("ToggleReadButton", () => {
+describe("DismissButton", () => {
   it("calls onAfterDismiss after marking as read", async () => {
     const onAfterDismiss = vi.fn();
     render(
-      <ToggleReadButton
-        article={unreadArticle}
-        onAfterDismiss={onAfterDismiss}
-      />,
+      <DismissButton article={unreadArticle} onAfterDismiss={onAfterDismiss} />,
     );
 
     await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
@@ -37,10 +34,7 @@ describe("ToggleReadButton", () => {
     const onAfterDismiss = vi.fn();
     const readArticle = { ...unreadArticle, readAt: new Date() };
     render(
-      <ToggleReadButton
-        article={readArticle}
-        onAfterDismiss={onAfterDismiss}
-      />,
+      <DismissButton article={readArticle} onAfterDismiss={onAfterDismiss} />,
     );
 
     await userEvent.click(screen.getByRole("button", { name: /restore/i }));


### PR DESCRIPTION
## What

Renames the article "toggle read" action to match its **intent** rather than its mechanism:

- `toggle-read-button.tsx` → `dismiss-button.tsx` (component `ToggleReadButton` → `DismissButton`)
- Updated the import and both usages in `article-card-actions.tsx`
- Renamed and updated the corresponding test file

## Why

The old name described the mechanism (flipping the `readAt` field) rather than what the user is actually doing. "Read" was also overloaded: `VisitButton` is labelled **"Read"** (go read the source), while this button flips `readAt` but is labelled **"Dismiss"/"Restore"**. Naming it `DismissButton` matches the label, aligns with the existing `onAfterDismiss` prop, and removes the collision.

`VisitButton` was intentionally left untouched — its name already reflects intent, and renaming it to "read" would reintroduce the ambiguity.

## Verification

- `tsc --noEmit` clean
- `dismiss-button.test.tsx` passes (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)