### PR TITLE
fix(charts): scale unread articles donut with its container

### DIFF
--- a/src/app/feed/unread-articles-pie-chart.tsx
+++ b/src/app/feed/unread-articles-pie-chart.tsx
@@ -45,7 +45,7 @@ const UnreadArticlesPieChart = ({ chartData }: UnreadArticlesChartProps) => {
           data={chartData}
           dataKey="unread"
           nameKey="feedTitle"
-          innerRadius={60}
+          innerRadius="50%"
           strokeWidth={5}
         >
           {(chartData ?? []).map((entry, index) => (


### PR DESCRIPTION
## Problem

`innerRadius` on the unread-articles donut was hardcoded to `60` (pixels) while `outerRadius` keeps Recharts' default of `"80%"`. The two are computed against different bases, so they cross over as the container shrinks.

Below roughly 150px of container width the 80% outer radius falls under 60px, the ring inverts, and **no sectors are drawn at all** — the card silently renders as just the centered total, with no error.

I hit this while verifying the Recharts v3 migration (#695) at a narrow viewport, where the container measured 141×141:

```
containerSize: [141, 141]
sectorCount:   0
```

This is not a v3 regression — v2 defaults `outerRadius` the same way — it just happened to surface during that work.

## Fix

Express `innerRadius` as a percentage so both radii share a basis.

## Verification

Measured in the browser against the real dashboard, reading the rendered sector path:

| Container | Before | After |
|---|---|---|
| 141×141 | 0 sectors | 6 sectors, outer 52.4 / inner 32.75 |
| 250×250 (design size) | 6 sectors, outer 96 / inner 60 | 6 sectors, outer 96 / **inner 60** |

At the design size the inner radius still resolves to exactly 60px, so the chart is pixel-identical where it already fit. It now degrades gracefully in narrow layouts instead of vanishing.

`tsc --noEmit`, `eslint src/`, `prettier --check` and `npm run test:components` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)