### PR TITLE
feat: show the author a feed publishes, not a guessed byline

### DIFF
--- a/prisma/migrations/20260805000000_add_article_author/migration.sql
+++ b/prisma/migrations/20260805000000_add_article_author/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN "author" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,7 @@ model Article {
   publicationDate DateTime
   description     String?
   content         String?
+  author          String?
   link            String
   commentsLink    String?
   readAt          DateTime?

--- a/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
+++ b/src/app/feed/[feedId]/article/[articleId]/ai-summary/page.tsx
@@ -7,6 +7,7 @@ import IntlRelativeTime from "@/components/intl-relative-time";
 import BackButton from "@/components/navigation/back-button";
 import TopNavigation from "@/components/navigation/top-navigation";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { articleAuthor } from "@/lib/article";
 import { auth } from "@/lib/auth";
 import prisma from "@/lib/prismaClient";
 import { headers } from "next/headers";
@@ -62,7 +63,7 @@ const AiSummary = async (props0: {
           </span>
         </div>
         <h2 className="text-2xl font-bold tracking-tight">{article.title}</h2>
-        <ArticleMeta author={article.scrape?.author} />
+        <ArticleMeta author={articleAuthor(article)} />
         {article.scrape ? (
           <div className="leading-relaxed">
             <AiSummaryStream articleId={article.id} />

--- a/src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx
+++ b/src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx
@@ -7,6 +7,7 @@ import IntlRelativeTime from "@/components/intl-relative-time";
 import BackButton from "@/components/navigation/back-button";
 import TopNavigation from "@/components/navigation/top-navigation";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { articleAuthor } from "@/lib/article";
 import { auth } from "@/lib/auth";
 import prisma from "@/lib/prismaClient";
 import { headers } from "next/headers";
@@ -62,11 +63,11 @@ const AudioSummary = async (props0: {
           </span>
         </div>
         <h2 className="text-2xl font-bold tracking-tight">{article.title}</h2>
-        <ArticleMeta author={article.scrape?.author} />
+        <ArticleMeta author={articleAuthor(article)} />
         {article.scrape ? (
           <AudioSummaryPlayer
             articleId={article.id}
-            author={article.scrape?.author}
+            author={articleAuthor(article)}
             feedTitle={article.feed.title}
             title={article.title}
           />

--- a/src/components/article/article-card.tsx
+++ b/src/components/article/article-card.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Prisma } from "@/generated/prisma/client";
 import { generateAiLead } from "@/lib/ai/services/leadService";
+import { articleAuthor } from "@/lib/article";
 import {
   markArticleAsRead,
   unmarkArticleAsRead,
@@ -140,7 +141,7 @@ const ArticleCard = (props: ArticleCardProps) => {
               {props.article.title}
             </h2>
 
-            <ArticleMeta author={props.article.scrape?.author} />
+            <ArticleMeta author={articleAuthor(props.article)} />
           </div>
         </div>
       </CardHeader>

--- a/src/lib/article.ts
+++ b/src/lib/article.ts
@@ -1,0 +1,16 @@
+/**
+ * The author to display for an article.
+ *
+ * The author declared in the feed wins: the publisher stated it deliberately,
+ * whereas Readability infers its byline from the article page and regularly
+ * picks up a section name, a "share" link, or nothing at all. The scraped
+ * byline is only a fallback for feeds that carry no author.
+ *
+ * The scraper stores "" when Readability finds no byline, so empty strings are
+ * treated the same as a missing value.
+ */
+export const articleAuthor = (article: {
+  author?: string | null;
+  scrape?: { author: string } | null;
+}): string | null =>
+  article.author?.trim() || article.scrape?.author?.trim() || null;

--- a/src/lib/repository/feedRepository.ts
+++ b/src/lib/repository/feedRepository.ts
@@ -113,6 +113,7 @@ export const refreshFeed = async (feedId: number) => {
       },
       update: {
         commentsLink: item.commentsLink,
+        author: item.author,
       },
     }),
   );

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -70,6 +70,103 @@ export const scrapeArticle = async (articleId: number, articleLink: string) => {
 
   return scrape;
 };
+// htmlparser2 exposes neither <comments> nor per-item authors, so both are read
+// straight off the feed source. The blocks are matched with a regex rather than
+// a second DOM pass because only a handful of elements are needed.
+const FEED_ITEM_PATTERN = /<(item|entry)(?:\s[^>]*)?>.*?<\/\1>/gs;
+
+const XML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+};
+
+const decodeFeedText = (value: string) =>
+  value
+    .replace(/<!\[CDATA\[(.*?)\]\]>/gs, "$1")
+    .replace(/<[^>]*>/g, "")
+    .replace(
+      /&(?:#(\d+)|#[xX]([\dA-Fa-f]+)|([A-Za-z]+));/g,
+      (match, dec, hex, name) => {
+        if (dec) return String.fromCodePoint(Number(dec));
+        if (hex) return String.fromCodePoint(parseInt(hex, 16));
+        return XML_ENTITIES[name] ?? match;
+      },
+    )
+    .replace(/\s+/g, " ")
+    .trim();
+
+const extractElement = (block: string, tagName: string) => {
+  const match = block.match(
+    new RegExp(`<${tagName}(?:\\s[^>]*)?>(.*?)</${tagName}>`, "s"),
+  );
+  return match ? decodeFeedText(match[1]) : null;
+};
+
+const extractItemLink = (block: string) => {
+  const rssLink = extractElement(block, "link");
+  if (rssLink) return rssLink;
+
+  // Atom puts the target in the href attribute of a self-closing <link>.
+  // htmlparser2 takes the first one regardless of its rel, so do the same.
+  const atomLink = block.match(/<link(?:\s[^>]*)?\shref="(.*?)"/s);
+  return atomLink ? decodeFeedText(atomLink[1]) : null;
+};
+
+const extractAuthor = (block: string) => {
+  // dc:creator carries a display name, whereas RSS 2.0 specifies <author> as an
+  // email address, so a creator is the better label whenever both are present.
+  const creators = [
+    ...block.matchAll(/<dc:creator(?:\s[^>]*)?>(.*?)<\/dc:creator>/gs),
+  ]
+    .map((match) => decodeFeedText(match[1]))
+    .filter((name) => name !== "");
+  if (creators.length > 0) return creators.join(", ");
+
+  const authors = [...block.matchAll(/<author(?:\s[^>]*)?>(.*?)<\/author>/gs)]
+    .map((match) => {
+      // Atom wraps the display name in <name>. RSS publishers that follow the
+      // email convention usually append the name: "jane@example.com (Jane Doe)".
+      const name = extractElement(match[1], "name");
+      if (name) return name;
+
+      const text = decodeFeedText(match[1]);
+      const parenthesised = text.match(/\(([^)]*)\)/);
+      return parenthesised ? parenthesised[1].trim() : text;
+    })
+    .filter((name) => name !== "");
+
+  return authors.length > 0 ? authors.join(", ") : null;
+};
+
+const extractItemMetadata = (feedSource: string) => {
+  const itemBlocks = [...feedSource.matchAll(FEED_ITEM_PATTERN)].map(
+    (match) => match[0],
+  );
+
+  // An Atom entry inherits the feed-level author when it declares none of its
+  // own (RFC 4287 §4.2.1), which is how single-author blogs usually publish.
+  const feedAuthor = extractAuthor(feedSource.replace(FEED_ITEM_PATTERN, ""));
+
+  const metadataByItemLink = new Map<
+    string,
+    { commentsLink: string | null; author: string | null }
+  >();
+  for (const block of itemBlocks) {
+    const link = extractItemLink(block);
+    if (!link) continue;
+
+    metadataByItemLink.set(link, {
+      commentsLink: extractElement(block, "comments"),
+      author: extractAuthor(block) ?? feedAuthor,
+    });
+  }
+
+  return metadataByItemLink;
+};
+
 export const scrapeFeed = async (feed: Feed) => {
   const fetchedFeed = await fetch(feed.link).then((res) => res.text());
   const parsedFeed = parseFeed(fetchedFeed);
@@ -82,33 +179,29 @@ export const scrapeFeed = async (feed: Feed) => {
     throw new Error("Unable to parse feed.");
   }
 
-  const itemBlocks = [...fetchedFeed.matchAll(/<item[\s>](.*?)<\/item>/gs)].map(
-    (m) => m[0],
-  );
-
-  const commentsLinkByItemLink = new Map<string, string>();
-  for (const block of itemBlocks) {
-    const linkMatch = block.match(/<link>(.*?)<\/link>/s);
-    const commentsMatch = block.match(/<comments>(.*?)<\/comments>/s);
-    if (linkMatch && commentsMatch) {
-      commentsLinkByItemLink.set(linkMatch[1].trim(), commentsMatch[1].trim());
-    }
-  }
+  const metadataByItemLink = extractItemMetadata(fetchedFeed);
 
   const validFeedItems: Pick<
     Article,
-    "title" | "link" | "description" | "publicationDate" | "commentsLink"
+    | "title"
+    | "link"
+    | "description"
+    | "publicationDate"
+    | "commentsLink"
+    | "author"
   >[] = [];
   parsedFeed.items.forEach((item) => {
     if (!item.title || !item.link || !item.pubDate) {
       logger.error({ item }, "Invalid feed item.");
     } else {
+      const metadata = metadataByItemLink.get(item.link);
       validFeedItems.push({
         title: item.title,
         link: item.link,
         description: item.description ? item.description : null,
         publicationDate: new Date(item.pubDate),
-        commentsLink: commentsLinkByItemLink.get(item.link) ?? null,
+        commentsLink: metadata?.commentsLink ?? null,
+        author: metadata?.author ?? null,
       });
     }
   });

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -6,7 +6,7 @@ import logger from "@/lib/logger";
 import prisma from "@/lib/prismaClient";
 import { Readability } from "@mozilla/readability";
 import axios from "axios";
-import { parseFeed } from "htmlparser2";
+import { DomUtils, parseDocument, parseFeed } from "htmlparser2";
 import DOMPurify from "isomorphic-dompurify";
 import { JSDOM } from "jsdom";
 
@@ -75,26 +75,19 @@ export const scrapeArticle = async (articleId: number, articleLink: string) => {
 // a second DOM pass because only a handful of elements are needed.
 const FEED_ITEM_PATTERN = /<(item|entry)(?:\s[^>]*)?>.*?<\/\1>/gs;
 
-const XML_ENTITIES: Record<string, string> = {
-  amp: "&",
-  lt: "<",
-  gt: ">",
-  quot: '"',
-  apos: "'",
-};
-
+// Reduces an element's raw inner XML to the plain text it stands for: entities
+// decoded, any markup around the value dropped. Parsing rather than unescaping
+// by hand keeps this identical to how htmlparser2 decoded the feed's own
+// fields, which matters because item links are used as lookup keys below.
 const decodeFeedText = (value: string) =>
-  value
-    .replace(/<!\[CDATA\[(.*?)\]\]>/gs, "$1")
-    .replace(/<[^>]*>/g, "")
-    .replace(
-      /&(?:#(\d+)|#[xX]([\dA-Fa-f]+)|([A-Za-z]+));/g,
-      (match, dec, hex, name) => {
-        if (dec) return String.fromCodePoint(Number(dec));
-        if (hex) return String.fromCodePoint(parseInt(hex, 16));
-        return XML_ENTITIES[name] ?? match;
-      },
-    )
+  DomUtils.textContent(
+    // As far as XML is concerned CDATA is literal text, but publishers use it
+    // to embed markup — typically a link wrapped around the author's name — so
+    // the section is unwrapped and its content parsed like everything else.
+    parseDocument(value.replace(/<!\[CDATA\[(.*?)\]\]>/gs, "$1"), {
+      xmlMode: true,
+    }),
+  )
     .replace(/\s+/g, " ")
     .trim();
 

--- a/tests/unit/article.test.ts
+++ b/tests/unit/article.test.ts
@@ -1,0 +1,30 @@
+import { articleAuthor } from "@/lib/article";
+import { describe, expect, it } from "vitest";
+
+describe("articleAuthor", () => {
+  it("prefers the feed author over the scraped byline", () => {
+    expect(
+      articleAuthor({ author: "Jane Doe", scrape: { author: "By Someone" } }),
+    ).toBe("Jane Doe");
+  });
+
+  it("falls back to the scraped byline when the feed has no author", () => {
+    expect(
+      articleAuthor({ author: null, scrape: { author: "By Someone" } }),
+    ).toBe("By Someone");
+  });
+
+  it("treats an empty scraped byline as no author", () => {
+    expect(articleAuthor({ author: null, scrape: { author: "" } })).toBeNull();
+  });
+
+  it("ignores a feed author that is only whitespace", () => {
+    expect(
+      articleAuthor({ author: "   ", scrape: { author: "By Someone" } }),
+    ).toBe("By Someone");
+  });
+
+  it("returns null when the article has not been scraped", () => {
+    expect(articleAuthor({ author: null, scrape: null })).toBeNull();
+  });
+});

--- a/tests/unit/audioSummaryPageLayout.test.ts
+++ b/tests/unit/audioSummaryPageLayout.test.ts
@@ -21,7 +21,7 @@ describe("Audio summary page layout", () => {
     // The opening line is built from these, so they must reach the client.
     expect(pageSource).toContain("<AudioSummaryPlayer");
     expect(pageSource).toContain("feedTitle={article.feed.title}");
-    expect(pageSource).toContain("author={article.scrape?.author}");
+    expect(pageSource).toContain("author={articleAuthor(article)}");
   });
 
   it("explains itself when the article body could not be retrieved", () => {

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("htmlparser2", () => ({
+// Only parseFeed is stubbed. The scraper also parses raw element content with
+// htmlparser2, and these tests assert on what that produces.
+vi.mock("htmlparser2", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("htmlparser2")>()),
   parseFeed: vi.fn(),
 }));
 
@@ -318,6 +321,40 @@ describe("scrapeFeed authors", () => {
     const items = await scrapeFeed(makeFeed());
 
     expect(items[0].author).toBe("Jane & John O'Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("unwraps markup around the author name", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <dc:creator><![CDATA[<a href="https://example.com/jane">Jane Doe</a>]]></dc:creator>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves no tag behind when the markup is nested", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <dc:creator><![CDATA[<<b>b>Jane Doe]]></dc:creator>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).not.toContain("<");
     vi.unstubAllGlobals();
   });
 

--- a/tests/unit/scraper.test.ts
+++ b/tests/unit/scraper.test.ts
@@ -217,3 +217,185 @@ describe("scrapeFeed", () => {
     vi.unstubAllGlobals();
   });
 });
+
+describe("scrapeFeed authors", () => {
+  const stubFeedSource = (xml: string, type: "rss2" | "atom" = "rss2") => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(xml)),
+    );
+    vi.mocked(parseFeed).mockReturnValue({
+      type,
+      id: "",
+      title: "Test",
+      link: "",
+      description: "",
+      items: [makeRssItem("Article 1", "https://example.com/1")],
+    } as ReturnType<typeof parseFeed>);
+  };
+
+  it("reads the author from <dc:creator>", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <dc:creator><![CDATA[Jane Doe]]></dc:creator>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("prefers <dc:creator> over the email in <author>", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <author>jane@example.com</author>
+          <dc:creator>Jane Doe</dc:creator>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("takes the name out of an RSS <author> email address", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <author>jane@example.com (Jane Doe)</author>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("joins multiple <dc:creator> elements", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <dc:creator>Jane Doe</dc:creator>
+          <dc:creator>John Roe</dc:creator>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe, John Roe");
+    vi.unstubAllGlobals();
+  });
+
+  it("decodes entities in the author name", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+          <dc:creator>Jane &amp; John O&#39;Doe</dc:creator>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane & John O'Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("reads the author from an Atom entry", async () => {
+    stubFeedSource(
+      `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <title>Article 1</title>
+          <link href="https://example.com/1"/>
+          <author><name>Jane Doe</name><email>jane@example.com</email></author>
+        </entry>
+      </feed>
+    `,
+      "atom",
+    );
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to the feed-level author for Atom entries without one", async () => {
+    stubFeedSource(
+      `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <author><name>Jane Doe</name></author>
+        <entry>
+          <title>Article 1</title>
+          <link href="https://example.com/1"/>
+        </entry>
+      </feed>
+    `,
+      "atom",
+    );
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("prefers the entry author over the feed-level author", async () => {
+    stubFeedSource(
+      `
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <author><name>Feed Owner</name></author>
+        <entry>
+          <title>Article 1</title>
+          <link href="https://example.com/1"/>
+          <author><name>Jane Doe</name></author>
+        </entry>
+      </feed>
+    `,
+      "atom",
+    );
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBe("Jane Doe");
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a null author when the feed declares none", async () => {
+    stubFeedSource(`
+      <rss><channel>
+        <managingEditor>editor@example.com</managingEditor>
+        <item>
+          <title>Article 1</title>
+          <link>https://example.com/1</link>
+        </item>
+      </channel></rss>
+    `);
+
+    const items = await scrapeFeed(makeFeed());
+
+    expect(items[0].author).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
Articles now display the author declared in the RSS or Atom feed. Readability's inferred byline is only a fallback for feeds that carry no author, so section names and stray links stop appearing where a name belongs. The spoken opening line of an audio summary uses the same author.

## Storage

`Article.author String?`, with migration `20260805000000_add_article_author`. Not applied to any dev database — run `npm run prisma:migrate-dev`.

## Parsing

htmlparser2 exposes no per-item author (domutils' `FeedItem` carries only id, title, link, description, pubDate, media), so the author is read off the feed source by the same regex pass that already extracted `<comments>`. `extractItemMetadata` now builds one map keyed by item link holding both values:

- `<dc:creator>` wins over `<author>` — RSS 2.0 specifies `<author>` as an email address, so a creator is the better display name when both are present. Repeated creators join with `", "`.
- `<author>` falls back to Atom's `<name>` child, otherwise the RSS `jane@example.com (Jane Doe)` convention, from which the parenthesised name is taken.
- An Atom entry with no author inherits the feed-level one (RFC 4287 §4.2.1) — how single-author blogs publish.
- Element content is reduced to plain text by parsing it back through htmlparser2 in the same `xmlMode` that produced the feed's own fields, so entities decode identically and any markup wrapped around a value is dropped. CDATA is unwrapped first: strictly it is literal text, but publishers use it to embed a link around the author's name and mean it as markup.

Parsing rather than unescaping by hand also fixes a latent bug: item links were used as map keys undecoded, so a link containing `&amp;` never matched htmlparser2's decoded `item.link` and silently lost its `commentsLink`. Matching `<entry>` alongside `<item>` is what lets Atom links resolve from the `href` attribute.

The second commit is that switch. The first version stripped tags with `/<[^>]*>/` next to a hand-rolled entity table, which CodeQL correctly flagged as incomplete multi-character sanitization — nothing exploitable, since the value lands in a React text node, but the wrong tool for the job.

## Display

`articleAuthor()` in `src/lib/article.ts` decides in one place, treating the empty string the scraper stores for a missing byline as absent. Used by the article card, the AI summary page, and the audio summary page including `AudioSummaryPlayer`.

## Verification

`npm run test` 142/142 pass — 11 new author cases in `tests/unit/scraper.test.ts` and a new `tests/unit/article.test.ts`. One source-text assertion in `audioSummaryPageLayout.test.ts` was updated for the new prop expression, and the `htmlparser2` mock there now keeps the real module and stubs only `parseFeed`. `npm run build` and `npm run format:check` pass. ESLint is clean on `src`, `tests`, and `prisma`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)