### PR TITLE
feat: generate and speak article briefings in the article's own language

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "firefox-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@mozilla/firefox-devtools-mcp@latest"],
+      "env": {}
+    }
+  }
+}

--- a/docs/superpowers/plans/2026-08-06-article-language.md
+++ b/docs/superpowers/plans/2026-08-06-article-language.md
@@ -1,0 +1,1713 @@
+# Language-Aware Article Processing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record each article's language and state it explicitly in every
+prompt, so a non-English article gets a lead, text summary, and audio briefing
+in its own language, spoken by a matching voice.
+
+**Architecture:** The model reports the article's language as a
+structured-output field alongside the lead already generated for every article
+at ingest. The value is validated and stored on `Article.language`; `null` means
+"never established" and resolves to English. All three prompts embed an explicit
+language directive. The audio briefing's introduction moves from hand-assembled
+code into the prompt, and the model delimits sentences with newlines so sentence
+splitting needs no language-specific knowledge.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Prisma 7 (SQLite), Vercel AI
+SDK (`ai@7`), Zod 4, Vitest (`node` and `components` projects), Web Speech API.
+
+Full design: `docs/superpowers/specs/2026-08-06-article-language-design.md`.
+
+## Global Constraints
+
+- Branch is `feat/article-language`, already created. Do **not** push to `main`.
+- Conventional Commits **without scopes** (`feat:`, `fix:`, `test:`,
+  `refactor:`, `docs:`, `chore:`). `feat:`/`fix:` first lines are user-facing
+  changelog copy.
+- Never bypass the Husky pre-commit hook (`--no-verify` is prohibited). Run
+  `npm run format` before committing if the hook reports unfixable formatting.
+- Language codes stored in the database are always lowercase two-letter ISO
+  639-1, or `null`. Never store `"und"`, `"deu"`, or a region suffix.
+- The application's own interface stays English. Only article-derived text is
+  translated.
+- `tests/integration/feedRepository.test.ts` already fails `npx tsc --noEmit` on
+  `main` (its `feedItem` factory is missing the `author` field added in
+  d6d61c7). Pre-existing, unrelated, does not gate `npm run build`. Do not fix
+  it here and do not be misled by it.
+- Verification commands: `npm run test` (all Vitest projects),
+  `npx vitest run --project node`, `npx vitest run --project components`,
+  `npm run lint`, `npm run build`.
+
+## File Structure
+
+**Created:**
+
+- `src/lib/language.ts` — the only place that decides whether a model-supplied
+  language code is storable, and the only place that maps a code to a display
+  name. Imported by both server (prompts) and client (player).
+- `tests/unit/language.test.ts`
+- `prisma/migrations/20260806000000_add_article_language/migration.sql`
+
+**Modified:**
+
+- `prisma/schema.prisma` — `Article.language String?`
+- `src/lib/ai/prompts.ts` — language directive helper; all three prompt builders
+- `src/lib/ai/services/leadService.ts` — `generateText` → `generateObject`;
+  writes the language
+- `src/lib/ai/services/summaryService.ts` — passes the language through
+- `src/lib/ai/services/audioScriptService.ts` — passes language, author, and
+  feed title through
+- `src/lib/audio-script.ts` — `buildOpeningLine` deleted; `splitIntoSentences`
+  becomes a newline split
+- `src/hooks/use-speech-synthesis.ts` — voice matching and a `voiceAvailable`
+  signal
+- `src/components/article/audio-summary-player.tsx` — new props, no constructed
+  opening, missing-voice alert
+- `src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx` — passes
+  `language` instead of `title`/`author`/`feedTitle`
+- `tests/unit/prompts.test.ts`, `tests/unit/audio-script.test.ts`,
+  `tests/unit/audioSummaryPageLayout.test.ts`
+- `tests/integration/leadService.test.ts`
+- `tests/helpers/speech-synthesis.ts`
+- `tests/components/hooks/use-speech-synthesis.test.tsx`
+- `tests/components/article/audio-summary-player.test.tsx`
+
+---
+
+### Task 1: The language module
+
+**Files:**
+
+- Create: `src/lib/language.ts`
+- Test: `tests/unit/language.test.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+  - `DEFAULT_LANGUAGE: "en"`
+  - `normalizeLanguage(value: string | null | undefined): string | null`
+  - `languageDisplayName(language: string | null): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/language.test.ts`:
+
+```ts
+import { languageDisplayName, normalizeLanguage } from "@/lib/language";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeLanguage", () => {
+  it("accepts a two-letter ISO 639-1 code", () => {
+    expect(normalizeLanguage("de")).toBe("de");
+    expect(normalizeLanguage("en")).toBe("en");
+  });
+
+  it("reduces a regional tag to its primary subtag", () => {
+    // Engines and models disagree on the separator.
+    expect(normalizeLanguage("de-DE")).toBe("de");
+    expect(normalizeLanguage("de_DE")).toBe("de");
+    expect(normalizeLanguage("pt-BR")).toBe("pt");
+  });
+
+  it("lowercases and trims", () => {
+    expect(normalizeLanguage("DE")).toBe("de");
+    expect(normalizeLanguage("  de  ")).toBe("de");
+  });
+
+  it("rejects the undetermined sentinel", () => {
+    // Load-bearing: Intl.DisplayNames.of("und") returns "root", so the
+    // recognition check does NOT catch it. Only the two-letter rule does.
+    expect(normalizeLanguage("und")).toBeNull();
+  });
+
+  it("rejects ISO 639-2 codes", () => {
+    // Load-bearing for the same reason: .of("deu") returns "German".
+    expect(normalizeLanguage("deu")).toBeNull();
+    expect(normalizeLanguage("ger")).toBeNull();
+  });
+
+  it("rejects language names and unrecognised codes", () => {
+    expect(normalizeLanguage("German")).toBeNull();
+    expect(normalizeLanguage("xx")).toBeNull();
+    expect(normalizeLanguage("un")).toBeNull();
+  });
+
+  it("rejects empty and missing values without throwing", () => {
+    // Intl.DisplayNames.of("") throws a RangeError, so the shape check has to
+    // run first.
+    expect(normalizeLanguage("")).toBeNull();
+    expect(normalizeLanguage("   ")).toBeNull();
+    expect(normalizeLanguage(null)).toBeNull();
+    expect(normalizeLanguage(undefined)).toBeNull();
+  });
+});
+
+describe("languageDisplayName", () => {
+  it("names a language in English", () => {
+    expect(languageDisplayName("de")).toBe("German");
+    expect(languageDisplayName("fr")).toBe("French");
+  });
+
+  it("falls back to English when no language was established", () => {
+    expect(languageDisplayName(null)).toBe("English");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run --project node tests/unit/language.test.ts` Expected: FAIL
+— cannot resolve `@/lib/language`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/language.ts`:
+
+```ts
+/**
+ * The language an article's generated text is written in.
+ *
+ * The model reports a language alongside the lead it generates (see
+ * leadService). Only values that survive `normalizeLanguage` are stored, and a
+ * null language means "never established", which resolves to English wherever
+ * it is read.
+ */
+
+export const DEFAULT_LANGUAGE = "en";
+
+const languageNames = new Intl.DisplayNames(["en"], { type: "language" });
+
+/**
+ * Reduces a model-supplied language to a storable ISO 639-1 code, or null.
+ *
+ * The order of the checks is load-bearing:
+ *
+ * - `Intl.DisplayNames.of("")` throws a RangeError rather than returning a
+ *   value, so the shape check is what keeps the lookup below safe.
+ * - `.of("deu")` returns "German" and `.of("und")` returns "root", so neither
+ *   ISO 639-2 codes nor the undetermined sentinel are caught by the
+ *   recognition check. The two-letter rule is the only thing that rejects
+ *   them. Reordering these would store both — and set them as
+ *   `utterance.lang`, where no browser matches them to a voice.
+ */
+export const normalizeLanguage = (
+  value: string | null | undefined,
+): string | null => {
+  const code = value?.trim().toLowerCase().split(/[-_]/)[0] ?? "";
+
+  if (!/^[a-z]{2}$/.test(code)) {
+    return null;
+  }
+
+  // A well-formed but unrecognised tag echoes itself back.
+  return languageNames.of(code) === code ? null : code;
+};
+
+/**
+ * The English name of a language, for prompt directives and reader-facing
+ * copy. The interface is English, so the names are too.
+ */
+export const languageDisplayName = (language: string | null): string =>
+  languageNames.of(language ?? DEFAULT_LANGUAGE) ?? "English";
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run --project node tests/unit/language.test.ts` Expected: PASS,
+9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/language.ts tests/unit/language.test.ts
+git commit -m "feat: add language code validation and naming"
+```
+
+---
+
+### Task 2: Language directives in the lead and summary prompts
+
+**Files:**
+
+- Modify: `src/lib/ai/prompts.ts`
+- Test: `tests/unit/prompts.test.ts`
+
+**Interfaces:**
+
+- Consumes: `languageDisplayName` from Task 1.
+- Produces:
+  - `buildLeadPrompt(title: string, textContent: string): string` — signature
+    unchanged; now instructs the model to report a language.
+  - `buildSummaryPrompt(title: string, textContent: string, language: string | null): string`
+  - `systemPrompt` — unchanged.
+  - `buildAudioScriptPrompt` — **not** touched in this task; Task 4 rewrites it.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/unit/prompts.test.ts`, replace the `describe("buildLeadPrompt", …)`
+and `describe("buildSummaryPrompt", …)` blocks with:
+
+```ts
+describe("buildLeadPrompt", () => {
+  it("includes the title and the article text", () => {
+    const prompt = buildLeadPrompt("My Title", "Body text here");
+    expect(prompt).toContain("My Title");
+    expect(prompt).toContain("Body text here");
+    expect(prompt).toContain("no longer than 80 words");
+  });
+
+  it("asks the model to report the language as an ISO 639-1 code", () => {
+    // The lead is the one call that determines the language; everything
+    // downstream reads what it stored.
+    const prompt = buildLeadPrompt("My Title", "Body text here");
+    expect(prompt).toContain("ISO 639-1");
+    expect(prompt).toContain('"und"');
+  });
+
+  it("asks for the lead in the language it reports", () => {
+    const prompt = buildLeadPrompt("My Title", "Body text here");
+    expect(prompt).toContain("in the language you reported");
+  });
+});
+
+describe("buildSummaryPrompt", () => {
+  it("includes the article text and Markdown structure cues", () => {
+    const prompt = buildSummaryPrompt("My Title", "Body text here", null);
+    expect(prompt).toContain("My Title");
+    expect(prompt).toContain("Body text here");
+    expect(prompt).toContain("Key Facts");
+    expect(prompt).toContain("Key Takeaways");
+  });
+
+  it("names the article's language", () => {
+    const prompt = buildSummaryPrompt("My Title", "Body text here", "de");
+    expect(prompt).toContain("Write entirely in German.");
+  });
+
+  it("falls back to English when no language was established", () => {
+    const prompt = buildSummaryPrompt("My Title", "Body text here", null);
+    expect(prompt).toContain("Write entirely in English.");
+  });
+
+  it("asks for the heading to be translated too", () => {
+    // The heading names are given in English as selection criteria, so
+    // without this a German summary gets German bullets under an English
+    // heading.
+    const prompt = buildSummaryPrompt("My Title", "Body text here", "de");
+    expect(prompt).toContain("translate the one you choose");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run --project node tests/unit/prompts.test.ts` Expected: FAIL —
+`buildSummaryPrompt` takes 2 arguments, and the new assertions find no matching
+text.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/lib/ai/prompts.ts`, add the import and helper at the top (leave
+`systemPrompt` as it is):
+
+```ts
+import { languageDisplayName } from "@/lib/language";
+
+/**
+ * The instruction that makes the output language deliberate rather than
+ * inferred. Stated even when the language is English: the point is that every
+ * generation is told what to write in, not that non-English is special-cased.
+ */
+const languageDirective = (language: string | null) =>
+  `Write entirely in ${languageDisplayName(language)}.`;
+```
+
+Replace `buildLeadPrompt`:
+
+```ts
+export const buildLeadPrompt = (title: string, textContent: string) =>
+  `Write a single paragraph summarizing what the article covers and why it is significant or timely. Be factual and objective. The summary must be no longer than 80 words. Do not copy the article's opening lines verbatim, and do not add introductory phrases, headings, or filler.
+
+First determine the language the article is written in and report it as a two-letter ISO 639-1 code, for example "de" for German. If the language cannot be established, report "und". Write the lead in the language you reported.
+
+<article>
+<title>${title}</title>
+<content>
+${textContent}
+</content>
+</article>`;
+```
+
+Replace `buildSummaryPrompt`:
+
+```ts
+export const buildSummaryPrompt = (
+  title: string,
+  textContent: string,
+  language: string | null,
+) =>
+  `Write a summary using the following Markdown structure: Use a level 3 heading (###) titled "Key Facts" for news and factual reporting, "Key Takeaways" for opinion or commentary, or "Key Points" if the article type is unclear. Follow the heading with a bullet list of 5–12 bullets — fewer for short or focused articles, more for complex ones. Each bullet must be one concise sentence. Bold the single most important named entity, concept, or figure in each bullet.
+
+${languageDirective(language)} The heading names above are given in English; translate the one you choose into that language.
+
+<article>
+<title>${title}</title>
+<content>
+${textContent}
+</content>
+</article>`;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run --project node tests/unit/prompts.test.ts` Expected: The
+`buildLeadPrompt` and `buildSummaryPrompt` suites PASS. The
+`buildAudioScriptPrompt` suite still passes untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ai/prompts.ts tests/unit/prompts.test.ts
+git commit -m "feat: state the output language in the lead and summary prompts"
+```
+
+---
+
+### Task 3: Store the language, and read it in the text summary
+
+**Files:**
+
+- Create: `prisma/migrations/20260806000000_add_article_language/migration.sql`
+- Modify: `prisma/schema.prisma`
+- Modify: `src/lib/ai/services/leadService.ts`
+- Modify: `src/lib/ai/services/summaryService.ts`
+- Test: `tests/integration/leadService.test.ts`
+
+**Interfaces:**
+
+- Consumes: `normalizeLanguage` (Task 1); `buildLeadPrompt`,
+  `buildSummaryPrompt` (Task 2).
+- Produces: `Article.language: string | null` in the Prisma client.
+  `generateAiLead(articleId: number): Promise<string>` — return type unchanged,
+  still the lead text.
+
+- [ ] **Step 1: Add the column**
+
+In `prisma/schema.prisma`, add `language` to the `Article` model, directly after
+`author`:
+
+```prisma
+author          String?
+language        String?
+```
+
+Create `prisma/migrations/20260806000000_add_article_language/migration.sql`:
+
+```sql
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN "language" TEXT;
+```
+
+Then regenerate the client:
+
+```bash
+npm run prisma:generate
+```
+
+Expected: "Generated Prisma Client". Tests apply the schema with
+`prisma db push` (see `vitest.setup.ts`), so they pick the column up without the
+migration; the migration file is what production deployments run.
+
+- [ ] **Step 2: Write the failing tests**
+
+Replace the whole of `tests/integration/leadService.test.ts` with:
+
+```ts
+import prisma from "@/lib/prismaClient";
+import { generateObject } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createArticle, createFeed, createUser } from "../helpers/factories";
+
+// Mock the AI registry's top-level model and the `ai` SDK BEFORE importing the service.
+vi.mock("@/lib/ai/registry", () => ({
+  getFirstConfiguredLanguageModel: vi.fn(async () => ({
+    modelId: "test-model",
+  })),
+}));
+vi.mock("ai", () => ({
+  generateObject: vi.fn(async () => ({
+    object: { language: "en", lead: "Generated lead." },
+    usage: { inputTokens: 7, outputTokens: 3 },
+  })),
+}));
+
+import { generateAiLead } from "@/lib/ai/services/leadService";
+
+const mockGeneration = (language: string, lead = "Generated lead.") =>
+  vi.mocked(generateObject).mockResolvedValueOnce({
+    object: { language, lead },
+    usage: { inputTokens: 7, outputTokens: 3 },
+  } as never);
+
+let userId: string;
+let feedId: number;
+
+beforeEach(async () => {
+  userId = (await createUser()).id;
+  feedId = (await createFeed({ userId })).id;
+});
+
+describe("generateAiLead", () => {
+  it("stores the generated lead and records token usage", async () => {
+    const article = await createArticle({ userId, feedId });
+
+    const result = await generateAiLead(article.id);
+
+    expect(result).toBe("Generated lead.");
+    const lead = await prisma.articleLead.findUniqueOrThrow({
+      where: { articleId: article.id },
+    });
+    expect(lead.text).toBe("Generated lead.");
+
+    const usage = await prisma.tokenUsage.findFirstOrThrow({
+      where: { userId },
+    });
+    expect(usage.inputTokens).toBe(7);
+    expect(usage.outputTokens).toBe(3);
+  });
+
+  it("stores the language the model reported", async () => {
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("de");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+    });
+    expect(stored.language).toBe("de");
+  });
+
+  it("normalises a regional tag before storing it", async () => {
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("de-DE");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+    });
+    expect(stored.language).toBe("de");
+  });
+
+  it("stores no language when the model reports it as undetermined", async () => {
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("und");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+    });
+    expect(stored.language).toBeNull();
+  });
+
+  it("keeps the lead when the reported language is unusable", async () => {
+    // A bad language code must not cost the reader their lead.
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("German", "Trotzdem ein Lead.");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+      include: { lead: true },
+    });
+    expect(stored.language).toBeNull();
+    expect(stored.lead?.text).toBe("Trotzdem ein Lead.");
+  });
+
+  it("replaces an existing lead rather than failing", async () => {
+    const article = await createArticle({ userId, feedId });
+    await generateAiLead(article.id);
+    mockGeneration("fr", "Un nouveau lead.");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+      include: { lead: true },
+    });
+    expect(stored.lead?.text).toBe("Un nouveau lead.");
+    expect(stored.language).toBe("fr");
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run --project node tests/integration/leadService.test.ts`
+Expected: FAIL — the service still imports `generateText`, which the mock no
+longer provides.
+
+- [ ] **Step 4: Rewrite the lead service**
+
+Replace `src/lib/ai/services/leadService.ts` with:
+
+```ts
+"use server";
+
+import { buildLeadPrompt, systemPrompt } from "@/lib/ai/prompts";
+import { getFirstConfiguredLanguageModel } from "@/lib/ai/registry";
+import { normalizeLanguage } from "@/lib/language";
+import logger from "@/lib/logger";
+import prisma from "@/lib/prismaClient";
+import { generateObject } from "ai";
+import { z } from "zod";
+import { trackTokenUsage } from "./tokenUsageService";
+
+const model = await getFirstConfiguredLanguageModel();
+
+// `language` is declared before `lead` deliberately. Structured output is
+// generated field by field, so the model commits to a language and then writes
+// the lead in it, rather than reporting one after the fact.
+//
+// "und" is the registered code for "undetermined". It is described explicitly
+// because it is the one permitted value that is not an ISO 639-1 code —
+// "two letters, or this one three-letter word" otherwise reads as a
+// contradiction and invites "un" or "unknown" instead. Nothing special-cases
+// it downstream: normalizeLanguage rejects it on length, like any other
+// unusable value.
+const leadSchema = z.object({
+  language: z
+    .string()
+    .describe(
+      'The article\'s language as a two-letter ISO 639-1 code, for example "de". Use "und" — the standard code for "undetermined" — if the language cannot be established.',
+    ),
+  lead: z.string(),
+});
+
+export const generateAiLead = async (articleId: number) => {
+  const article = await prisma.article.findUniqueOrThrow({
+    include: { scrape: true },
+    where: { id: articleId },
+  });
+
+  const { object, usage } = await generateObject({
+    model,
+    schema: leadSchema,
+    system: systemPrompt,
+    prompt: buildLeadPrompt(article.title, article.scrape?.textContent ?? ""),
+  });
+
+  const language = normalizeLanguage(object.language);
+
+  // One nested write, so the language cannot drift out of step with the lead
+  // it was determined alongside.
+  await prisma.article.update({
+    where: { id: articleId },
+    data: {
+      language,
+      lead: {
+        upsert: {
+          create: { text: object.lead },
+          update: { text: object.lead },
+        },
+      },
+    },
+  });
+
+  await trackTokenUsage(
+    article.userId,
+    model.modelId,
+    usage.inputTokens ?? 0,
+    usage.outputTokens ?? 0,
+  );
+
+  logger.info(
+    {
+      articleId,
+      feedId: article.feedId,
+      language,
+      model: model.modelId,
+      tokenUsage: usage,
+    },
+    "AI lead generated.",
+  );
+
+  return object.lead;
+};
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run --project node tests/integration/leadService.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Pass the language into the summary**
+
+In `src/lib/ai/services/summaryService.ts`, change the `buildSummaryPrompt` call
+to pass the stored language:
+
+```ts
+      prompt: buildSummaryPrompt(
+        article.title,
+        article.scrape?.textContent ?? "",
+        article.language,
+      ),
+```
+
+And add `language` to the log payload so a wrong-language summary is diagnosable
+without reproducing it:
+
+```ts
+logger.info(
+  {
+    articleId,
+    feedId: article.feedId,
+    language: article.language,
+    model: model.modelId,
+    tokenUsage,
+  },
+  "AI summary generated.",
+);
+```
+
+- [ ] **Step 7: Verify nothing else broke**
+
+Run: `npx vitest run --project node` Expected: PASS.
+(`tests/integration/feedRepository.test.ts` runs fine — its known problem is a
+typecheck-only issue.)
+
+Run: `npm run lint` Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations src/lib/ai/services/leadService.ts src/lib/ai/services/summaryService.ts tests/integration/leadService.test.ts
+git commit -m "feat: write summaries in the language of the article"
+```
+
+---
+
+### Task 4: The audio briefing writes its own introduction
+
+**Files:**
+
+- Modify: `src/lib/ai/prompts.ts`
+- Modify: `src/lib/audio-script.ts`
+- Modify: `src/lib/ai/services/audioScriptService.ts`
+- Test: `tests/unit/prompts.test.ts`, `tests/unit/audio-script.test.ts`
+
+**Interfaces:**
+
+- Consumes: `languageDirective` (Task 2, module-private), `articleAuthor` from
+  `@/lib/article`, `Article.language` (Task 3).
+- Produces:
+  - `buildAudioScriptPrompt(args: { title: string; author: string | null; feedTitle: string; textContent: string; language: string | null }): string`
+  - `splitIntoSentences(buffer: string): { sentences: string[]; remainder: string }`
+    — contract unchanged, implementation now a newline split.
+  - `buildOpeningLine` — **deleted**. Task 6 removes its last caller.
+
+- [ ] **Step 1: Write the failing prompt tests**
+
+In `tests/unit/prompts.test.ts`, replace the whole
+`describe("buildAudioScriptPrompt", …)` block with:
+
+```ts
+describe("buildAudioScriptPrompt", () => {
+  const args = {
+    title: "My Title",
+    author: "Jane Doe",
+    feedTitle: "Hacker News",
+    textContent: "Body text here",
+    language: null as string | null,
+  };
+
+  it("includes the title, the article text, and the publication", () => {
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("My Title");
+    expect(prompt).toContain("Body text here");
+    expect(prompt).toContain("Hacker News");
+  });
+
+  it("asks for spoken prose of about one minute", () => {
+    expect(buildAudioScriptPrompt(args)).toContain("150 to 200 words");
+  });
+
+  it("forbids Markdown, since the output is spoken rather than rendered", () => {
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("Markdown");
+    expect(prompt).toContain("plain text only");
+  });
+
+  it("asks the model to introduce the article itself", () => {
+    // The introduction used to be assembled in code; the model writes it now
+    // so it is phrased naturally in the article's own language.
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("state its title exactly as given");
+    expect(prompt).not.toContain("already been introduced");
+  });
+
+  it("supplies the author when one is known", () => {
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("<author>Jane Doe</author>");
+    expect(prompt).toContain("Name the author too.");
+  });
+
+  it("omits the author entirely when none is known", () => {
+    // Structural guard: with no author element in the prompt there is nothing
+    // for the model to invent one from.
+    const prompt = buildAudioScriptPrompt({ ...args, author: null });
+    expect(prompt).not.toContain("<author>");
+    expect(prompt).toContain("do not mention one");
+  });
+
+  it("asks for one sentence per line", () => {
+    // Playback splits the stream on newlines, so this instruction is what
+    // makes sentence boundaries work in every language.
+    expect(buildAudioScriptPrompt(args)).toContain("own line");
+  });
+
+  it("names the article's language", () => {
+    const prompt = buildAudioScriptPrompt({ ...args, language: "de" });
+    expect(prompt).toContain("Write entirely in German.");
+  });
+
+  it("falls back to English when no language was established", () => {
+    expect(buildAudioScriptPrompt(args)).toContain(
+      "Write entirely in English.",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run --project node tests/unit/prompts.test.ts` Expected: FAIL —
+`buildAudioScriptPrompt` still takes positional arguments.
+
+- [ ] **Step 3: Rewrite the audio script prompt**
+
+In `src/lib/ai/prompts.ts`, replace `buildAudioScriptPrompt` with:
+
+```ts
+/**
+ * Takes an object rather than positional arguments: four of the five fields
+ * are strings, and three of those are freely transposable at a call site
+ * without a type error.
+ */
+export const buildAudioScriptPrompt = ({
+  title,
+  author,
+  feedTitle,
+  textContent,
+  language,
+}: {
+  title: string;
+  author: string | null;
+  feedTitle: string;
+  textContent: string;
+  language: string | null;
+}) => {
+  // Omitted rather than left empty when unknown, so there is nothing in the
+  // prompt for the model to invent an author from.
+  const authorInstruction = author
+    ? " Name the author too."
+    : " No author is known, so do not mention one.";
+  const authorElement = author ? `<author>${author}</author>\n` : "";
+
+  return `Write a spoken audio briefing that a text-to-speech voice will read aloud.
+
+Open by introducing the article: state its title exactly as given below, without paraphrasing or translating it, then name the publication.${authorInstruction} Do not open with a greeting.
+
+After the introduction, write 150 to 200 words of continuous prose — roughly one minute of speech. Use short declarative sentences. Connect them with explicit transitions so the briefing flows when heard rather than read. Write numbers, symbols, and units the way they are spoken, for example "forty percent" rather than "40%". Avoid parenthetical asides, which cannot be heard.
+
+Put each sentence on its own line, separated by a single newline. Do not leave blank lines between sentences.
+
+Output plain text only. Do not use Markdown, headings, bullet lists, bold, or italics.
+
+${languageDirective(language)}
+
+<article>
+<title>${title}</title>
+${authorElement}<publication>${feedTitle}</publication>
+<content>
+${textContent}
+</content>
+</article>`;
+};
+```
+
+- [ ] **Step 4: Run the prompt tests to verify they pass**
+
+Run: `npx vitest run --project node tests/unit/prompts.test.ts` Expected: PASS,
+all suites.
+
+- [ ] **Step 5: Write the failing splitter tests**
+
+Replace the whole of `tests/unit/audio-script.test.ts` with:
+
+```ts
+import { splitIntoSentences } from "@/lib/audio-script";
+import { describe, expect, it } from "vitest";
+
+describe("splitIntoSentences", () => {
+  it("returns complete lines and keeps the unterminated tail", () => {
+    expect(
+      splitIntoSentences("Linux 7.2 drops strncpy.\nIt landed Fri"),
+    ).toEqual({
+      sentences: ["Linux 7.2 drops strncpy."],
+      remainder: "It landed Fri",
+    });
+  });
+
+  it("finds several sentences in one buffer", () => {
+    expect(splitIntoSentences("One.\nTwo.\nThree")).toEqual({
+      sentences: ["One.", "Two."],
+      remainder: "Three",
+    });
+  });
+
+  it("holds everything back until a newline arrives", () => {
+    expect(splitIntoSentences("It cost 3.")).toEqual({
+      sentences: [],
+      remainder: "It cost 3.",
+    });
+  });
+
+  it("does not split on punctuation inside a line", () => {
+    // The whole point of delimiting on newlines: no abbreviation list, so
+    // "z.B." and "Dr." are equally safe in any language.
+    expect(
+      splitIntoSentences("Laut Dr. Schmidt, z.B. in Berlin, gilt das.\nDann"),
+    ).toEqual({
+      sentences: ["Laut Dr. Schmidt, z.B. in Berlin, gilt das."],
+      remainder: "Dann",
+    });
+  });
+
+  it("keeps a sentence whole across an abbreviation no English list knew", () => {
+    // The discriminating case for the rewrite: the old punctuation splitter
+    // fragmented this at "usw." because that abbreviation was absent from its
+    // English list. Newline delimiting has no such list to be absent from.
+    //
+    // The test above does NOT discriminate — "dr" was in the old abbreviation
+    // set and "z.B." ends in a single letter, which the old algorithm also
+    // declined to split on, so it passes against both implementations. Keep
+    // both: that one documents intent, this one proves the claim.
+    expect(splitIntoSentences("Vorher usw. Nachher.\nDanach")).toEqual({
+      sentences: ["Vorher usw. Nachher."],
+      remainder: "Danach",
+    });
+  });
+
+  it("ignores blank lines", () => {
+    expect(splitIntoSentences("One.\n\nTwo.\nThree")).toEqual({
+      sentences: ["One.", "Two."],
+      remainder: "Three",
+    });
+  });
+
+  it("trims surrounding whitespace from each sentence", () => {
+    expect(splitIntoSentences("  One.  \n Two. \nThree")).toEqual({
+      sentences: ["One.", "Two."],
+      remainder: "Three",
+    });
+  });
+
+  it("returns nothing for empty input", () => {
+    expect(splitIntoSentences("")).toEqual({ sentences: [], remainder: "" });
+  });
+
+  it("survives being fed its own remainder with the next delta appended", () => {
+    // How the player actually drives it, one streamed chunk at a time.
+    const first = splitIntoSentences("One.\nTwo");
+    expect(first.sentences).toEqual(["One."]);
+
+    const second = splitIntoSentences(`${first.remainder} and a half.\nThree`);
+    expect(second).toEqual({
+      sentences: ["Two and a half."],
+      remainder: "Three",
+    });
+  });
+});
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `npx vitest run --project node tests/unit/audio-script.test.ts` Expected:
+FAIL — the punctuation splitter splits `"Laut Dr. Schmidt…"` in the wrong place
+and never treats `"\n"` as a delimiter.
+
+- [ ] **Step 7: Rewrite the splitter**
+
+Replace the whole of `src/lib/audio-script.ts` with:
+
+```ts
+/**
+ * Splits a buffer into complete sentences plus whatever is left over.
+ *
+ * The audio script prompt asks the model to put each sentence on its own line,
+ * so the delimiter is a newline rather than something inferred from
+ * punctuation. That keeps this free of language-specific knowledge: an English
+ * abbreviation list would mis-split German ("z.B.") and every other language in
+ * its own way.
+ *
+ * If the model ignores the instruction and emits no newlines at all, the whole
+ * briefing arrives as one utterance and runs into the roughly 15 second
+ * cut-off Chrome applies to a single long one. That is accepted rather than
+ * defended against — see the design's note on the rejected length fallback.
+ *
+ * Safe to call repeatedly against a growing stream: feed the remainder back in
+ * with the next delta appended.
+ */
+export const splitIntoSentences = (
+  buffer: string,
+): { sentences: string[]; remainder: string } => {
+  const lines = buffer.split("\n");
+
+  // Whatever follows the final newline is a sentence the stream has not
+  // finished delivering. It is left untrimmed because the caller appends the
+  // next delta directly to it.
+  const remainder = lines.pop() ?? "";
+
+  return {
+    sentences: lines.map((line) => line.trim()).filter((line) => line !== ""),
+    remainder,
+  };
+};
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `npx vitest run --project node tests/unit/audio-script.test.ts` Expected:
+PASS, 9 tests.
+
+Note: only the `usw.` case fails against the old splitter. The other eight pass
+against both implementations, because the old algorithm treated `\n` as
+sentence-terminating whitespace. Do not read their passing before the swap as a
+sign the swap is unnecessary.
+
+- [ ] **Step 9: Feed the prompt from the article**
+
+Replace the `streamText` call in `src/lib/ai/services/audioScriptService.ts` so
+the model receives everything the introduction needs. Add
+`import { articleAuthor } from "@/lib/article";` at the top, and add
+`feed: true` to the query's `include`:
+
+```ts
+const article = await prisma.article.findUniqueOrThrow({
+  where: { id: articleId, userId },
+  include: { feed: true, scrape: true },
+});
+```
+
+```ts
+const { textStream, totalUsage } = streamText({
+  model,
+  system: systemPrompt,
+  prompt: buildAudioScriptPrompt({
+    title: article.title,
+    // The existing helper, so the feed-declared author keeps winning over
+    // Readability's byline and no second notion of "the author" appears.
+    author: articleAuthor(article),
+    feedTitle: article.feed.title,
+    textContent: article.scrape?.textContent ?? "",
+    language: article.language,
+  }),
+});
+```
+
+And add `language` to the log payload:
+
+```ts
+logger.info(
+  {
+    articleId,
+    feedId: article.feedId,
+    language: article.language,
+    model: model.modelId,
+    tokenUsage,
+  },
+  "Audio script generated.",
+);
+```
+
+- [ ] **Step 10: Verify the node suite**
+
+Run: `npx vitest run --project node` Expected: PASS.
+
+Run: `npm run lint` Expected: no errors. (The `components` project still fails
+at this point — Task 6 updates the player. That is expected mid-plan.)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/lib/ai/prompts.ts src/lib/audio-script.ts src/lib/ai/services/audioScriptService.ts tests/unit/prompts.test.ts tests/unit/audio-script.test.ts
+git commit -m "feat: speak audio briefings in the language of the article"
+```
+
+---
+
+### Task 5: Match the voice to the language
+
+**Files:**
+
+- Modify: `src/hooks/use-speech-synthesis.ts`
+- Modify: `tests/helpers/speech-synthesis.ts`
+- Test: `tests/components/hooks/use-speech-synthesis.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `DEFAULT_LANGUAGE` from Task 1.
+- Produces:
+  `useSpeechSynthesis(language: string | null): SpeechSynthesisControls`, where
+  `SpeechSynthesisControls` gains `voiceAvailable: boolean`. All existing
+  members keep their names and types.
+
+- [ ] **Step 1: Teach the test fakes about languages**
+
+In `tests/helpers/speech-synthesis.ts`, add the two fields a real utterance
+carries, to `FakeUtterance`:
+
+```ts
+export class FakeUtterance {
+  text: string;
+  rate = 1;
+  lang = "";
+  voice: unknown = undefined;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+```
+
+Change the default voice list in `installSpeechEngine` so voices carry a `lang`,
+matching what a real engine reports:
+
+```ts
+export const installSpeechEngine = (
+  voices: unknown[] = [{ name: "Test Voice", lang: "en-US" }],
+) => {
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/components/hooks/use-speech-synthesis.test.tsx`, inside the
+existing `describe("useSpeechSynthesis", …)` block:
+
+```ts
+it("speaks with a voice matching the article's language", () => {
+  const german = { name: "Anna", lang: "de-DE" };
+  const engine = installSpeechEngine([
+    { name: "Test Voice", lang: "en-US" },
+    german,
+  ]);
+
+  const { result } = renderHook(() => useSpeechSynthesis("de"));
+  act(() => result.current.enqueue("Guten Tag."));
+  act(() => result.current.playFrom(0));
+
+  expect(result.current.voiceAvailable).toBe(true);
+  expect(engine.spoken()[0].voice).toBe(german);
+  expect(engine.spoken()[0].lang).toBe("de");
+});
+
+it("matches voices that report an underscore separator", () => {
+  // Chrome reports "de-DE"; some Linux engines report "de_DE".
+  const german = { name: "Anna", lang: "de_DE" };
+  const engine = installSpeechEngine([german]);
+
+  const { result } = renderHook(() => useSpeechSynthesis("de"));
+  act(() => result.current.enqueue("Guten Tag."));
+  act(() => result.current.playFrom(0));
+
+  expect(engine.spoken()[0].voice).toBe(german);
+});
+
+it("leaves the voice unset when none matches, but still speaks", () => {
+  const engine = installSpeechEngine([{ name: "Test Voice", lang: "en-US" }]);
+
+  const { result } = renderHook(() => useSpeechSynthesis("de"));
+  act(() => result.current.enqueue("Guten Tag."));
+  act(() => result.current.playFrom(0));
+
+  expect(result.current.supported).toBe(true);
+  expect(result.current.voiceAvailable).toBe(false);
+  // The engine gets its own fallback rather than an undefined voice, and
+  // `lang` still tells it what it is reading.
+  expect(engine.spoken()[0].voice).toBeUndefined();
+  expect(engine.spoken()[0].lang).toBe("de");
+});
+
+it("treats a missing language as English", () => {
+  const english = { name: "Test Voice", lang: "en-US" };
+  const engine = installSpeechEngine([english]);
+
+  const { result } = renderHook(() => useSpeechSynthesis(null));
+  act(() => result.current.enqueue("Hello."));
+  act(() => result.current.playFrom(0));
+
+  expect(result.current.voiceAvailable).toBe(true);
+  expect(engine.spoken()[0].voice).toBe(english);
+  expect(engine.spoken()[0].lang).toBe("en");
+});
+
+it("finds a matching voice that loads late", () => {
+  const voices: unknown[] = [];
+  const engine = installSpeechEngine(voices);
+
+  const { result } = renderHook(() => useSpeechSynthesis("de"));
+  expect(result.current.voiceAvailable).toBe(false);
+
+  voices.push({ name: "Anna", lang: "de-DE" });
+  const [, listener] = engine.addEventListener.mock.calls[0];
+  act(() => listener());
+
+  expect(result.current.voiceAvailable).toBe(true);
+});
+```
+
+Then make the existing tests compile against the new signature: replace
+**every** occurrence of `useSpeechSynthesis()` in this file with
+`useSpeechSynthesis("en")` — the hook now takes a required argument, so a bare
+call is a type error. In "becomes supported once voices have loaded", also
+change the pushed voice from `{ name: "Test Voice" }` to
+`{ name: "Test Voice", lang: "en-US" }`, so it matches what a real engine
+reports.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run:
+`npx vitest run --project components tests/components/hooks/use-speech-synthesis.test.tsx`
+Expected: FAIL — `voiceAvailable` is undefined and utterances carry no `lang` or
+`voice`.
+
+- [ ] **Step 4: Implement voice matching**
+
+In `src/hooks/use-speech-synthesis.ts`:
+
+Add to the imports:
+
+```ts
+import { DEFAULT_LANGUAGE } from "@/lib/language";
+```
+
+Add `voiceAvailable` to the interface, keeping the members alphabetical as they
+already are:
+
+```ts
+interface SpeechSynthesisControls {
+  activeIndex: number | undefined;
+  cancel: () => void;
+  enqueue: (sentence: string) => void;
+  pause: () => void;
+  paused: boolean;
+  playFrom: (index: number) => void;
+  rate: number;
+  resume: () => void;
+  setRate: (rate: number) => void;
+  speaking: boolean;
+  supported: boolean;
+  voiceAvailable: boolean;
+}
+```
+
+Change the signature and add the two new pieces of state:
+
+```ts
+export function useSpeechSynthesis(
+  language: string | null,
+): SpeechSynthesisControls {
+  const [supported, setSupported] = React.useState(false);
+  const [voiceAvailable, setVoiceAvailable] = React.useState(false);
+```
+
+Just below `const activeIndexValue = …`, add:
+
+```ts
+// Resolved once here so every utterance and the voice lookup agree on it.
+const spokenLanguage = language ?? DEFAULT_LANGUAGE;
+
+// Read at speak() time rather than through state, because sentences are
+// handed to the engine as they stream in, outside a render.
+const voice = React.useRef<SpeechSynthesisVoice | undefined>(undefined);
+```
+
+Replace the support effect with one that also resolves the voice:
+
+```ts
+React.useEffect(() => {
+  if (typeof window === "undefined" || !("speechSynthesis" in window)) {
+    return;
+  }
+
+  // getVoices() is populated asynchronously in Chrome, so an empty list only
+  // means "no voices" after voiceschanged has fired. Linux without
+  // speech-dispatcher installed never reports any.
+  const syncVoices = () => {
+    const voices = window.speechSynthesis.getVoices();
+    setSupported(voices.length > 0);
+
+    // Engines disagree on the separator: Chrome reports "de-DE", some Linux
+    // engines "de_DE".
+    const match = voices.find(
+      (candidate) =>
+        candidate.lang?.toLowerCase().split(/[-_]/)[0] === spokenLanguage,
+    );
+    voice.current = match;
+    setVoiceAvailable(match !== undefined);
+  };
+
+  syncVoices();
+  window.speechSynthesis.addEventListener("voiceschanged", syncVoices);
+
+  return () =>
+    window.speechSynthesis?.removeEventListener("voiceschanged", syncVoices);
+}, [spokenLanguage]);
+```
+
+In `speakSentence`, set the language and voice on each utterance, and add the
+dependency:
+
+```ts
+const utterance = new SpeechSynthesisUtterance(sentences.current[index]);
+utterance.rate = rateValue.current;
+utterance.lang = spokenLanguage;
+
+// Assigned only when a match exists: handing the engine an undefined
+// voice is not the same as leaving it to pick its own default.
+if (voice.current) {
+  utterance.voice = voice.current;
+}
+```
+
+```ts
+    [spokenLanguage],
+  );
+```
+
+Finally add `voiceAvailable` to the returned object, after `supported`:
+
+```ts
+    supported,
+    voiceAvailable,
+  };
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+`npx vitest run --project components tests/components/hooks/use-speech-synthesis.test.tsx`
+Expected: PASS. The player suite still fails — Task 6 fixes it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/use-speech-synthesis.ts tests/helpers/speech-synthesis.ts tests/components/hooks/use-speech-synthesis.test.tsx
+git commit -m "feat: read briefings with a voice matching the article's language"
+```
+
+---
+
+### Task 6: Wire the player and the page
+
+**Files:**
+
+- Modify: `src/components/article/audio-summary-player.tsx`
+- Modify: `src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx`
+- Test: `tests/components/article/audio-summary-player.test.tsx`,
+  `tests/unit/audioSummaryPageLayout.test.ts`
+
+**Interfaces:**
+
+- Consumes: `useSpeechSynthesis(language)` and `voiceAvailable` (Task 5);
+  `languageDisplayName` (Task 1); `splitIntoSentences` (Task 4);
+  `Article.language` (Task 3).
+- Produces:
+  `AudioSummaryPlayerProps = { articleId: number; language: string | null }`.
+
+- [ ] **Step 1: Update the page-layout test**
+
+In `tests/unit/audioSummaryPageLayout.test.ts`, replace the "passes the
+article's own metadata to the player" test with:
+
+```ts
+it("passes the article's language to the player", () => {
+  // The player needs it to pick a voice. The title, author, and publication
+  // no longer travel to the client: the server action loads them itself for
+  // the generated introduction.
+  expect(pageSource).toContain("<AudioSummaryPlayer");
+  expect(pageSource).toContain("language={article.language}");
+  expect(pageSource).not.toContain("feedTitle={article.feed.title}");
+});
+```
+
+- [ ] **Step 2: Update the player tests**
+
+In `tests/components/article/audio-summary-player.test.tsx`, make these edits.
+
+Change the streamed chunks so they are newline-delimited, in the
+`vi.mock("@ai-sdk/rsc", …)` block:
+
+```ts
+vi.mock("@ai-sdk/rsc", () => ({
+  readStreamableValue: vi.fn(() => ({
+    async *[Symbol.asyncIterator]() {
+      yield "Kernel 7.2 removes strncpy, from Hacker News, by Jane Doe.\n";
+      yield "It landed after 362 patches.\n";
+      yield "Maintainers had warned for years.";
+    },
+  })),
+}));
+```
+
+Replace the `props` object:
+
+```ts
+const props = {
+  articleId: 42,
+  language: "en",
+};
+```
+
+Replace the first test ("speaks the constructed opening before any generated
+text arrives") with:
+
+```ts
+  it("speaks nothing until the first generated sentence arrives", () => {
+    const engine = installSpeechEngine();
+
+    render(<AudioSummaryPlayer {...props} />);
+
+    // The introduction is generated now, so there is no locally-built opening
+    // to play during the model's time to first token.
+    expect(engine.speak).not.toHaveBeenCalled();
+  });
+```
+
+In "speaks each generated sentence as it streams in", replace the expected
+array:
+
+```ts
+      expect(engine.spoken().map((utterance) => utterance.text)).toEqual([
+        "Kernel 7.2 removes strncpy, from Hacker News, by Jane Doe.",
+        "It landed after 362 patches.",
+        "Maintainers had warned for years.",
+      ]),
+```
+
+"highlights the sentence the engine reports as started" needs **no edit**: index
+1 is still "It landed after 362 patches.", since the generated introduction now
+occupies index 0 that the constructed opening used to.
+
+In "restarts from the first sentence", replace the final assertion:
+
+```ts
+const respoken = engine.spoken().slice(3);
+expect(respoken[0].text).toBe(
+  "Kernel 7.2 removes strncpy, from Hacker News, by Jane Doe.",
+);
+```
+
+Replace "keeps the spoken opening and explains itself when generation fails"
+with:
+
+```ts
+  it("explains itself when generation fails", async () => {
+    installSpeechEngine();
+    vi.mocked(readStreamableValue).mockImplementationOnce(
+      () =>
+        ({
+          async *[Symbol.asyncIterator]() {
+            throw new Error("model unavailable");
+          },
+        }) as never,
+    );
+
+    render(<AudioSummaryPlayer {...props} />);
+
+    expect(await screen.findByText(/briefing incomplete/i)).toBeInTheDocument();
+  });
+```
+
+Replace the whole of "applies a stored rate only once, despite Strict Mode
+double-invoking effects".
+
+**Read this note before editing it — it records a real loss of coverage.** The
+old assertion counted live utterances whose text started with the opening, and
+it worked only because the opening was enqueued synchronously at mount, _before_
+the stored rate was applied: a second `setRate` then re-spoke it and produced
+two. With the introduction moved into the stream, every sentence now arrives
+_after_ the rate has been restored, so a duplicated `setRate` cancels and
+re-speaks a queue that is still empty. Since nothing is ever queued at the point
+the rate is restored, the `restoredRate` ref that used to guard against a
+redundant cancel had no observable effect any more, through the speech engine or
+otherwise — so it was deleted. Do not attempt to preserve the old assertion; it
+would pass with the guard deleted.
+
+What replaces it is a weaker but honest invariant — under Strict Mode each
+sentence still reaches the live queue exactly once — renamed so nobody reads it
+as covering the rate guard:
+
+```ts
+  it("speaks each sentence exactly once under Strict Mode", async () => {
+    window.localStorage.setItem("briefing-officer:speech-rate", "1.5");
+    const engine = installSpeechEngine();
+
+    render(
+      <React.StrictMode>
+        <AudioSummaryPlayer {...props} />
+      </React.StrictMode>,
+    );
+
+    await waitFor(() => expect(screen.getByText("1.5×")).toBeInTheDocument());
+    await waitFor(() => expect(engine.spoken().length).toBeGreaterThanOrEqual(3));
+
+    // Count only utterances queued after the last cancel: the fake's cancel()
+    // does not discard queued utterances the way a real engine does, so
+    // spoken() also contains ones that were cancelled before making a sound.
+    const lastCancel = Math.max(0, ...engine.cancel.mock.invocationCallOrder);
+    const live = engine.speak.mock.calls
+      .filter(
+        (_, index) => engine.speak.mock.invocationCallOrder[index] > lastCancel,
+      )
+      .map((call) => (call[0] as unknown as { text: string }).text);
+
+    expect(live).toEqual([
+      "Kernel 7.2 removes strncpy, from Hacker News, by Jane Doe.",
+      "It landed after 362 patches.",
+      "Maintainers had warned for years.",
+    ]);
+    expect(engine.spoken().at(-1)!.rate).toBe(1.5);
+  });
+```
+
+Replace the whole of "still speaks the opening after Strict Mode's cleanup
+cancels playback". Its premise survives — the remount branch must replay the
+retained sentences after the cleanup's cancel — but the sentence it looks for
+now arrives from the stream, so the assertion has to wait for it rather than
+only for the cancel:
+
+```ts
+  it("still speaks the briefing after Strict Mode's cleanup cancels playback", async () => {
+    const engine = installSpeechEngine();
+
+    render(
+      <React.StrictMode>
+        <AudioSummaryPlayer {...props} />
+      </React.StrictMode>,
+    );
+
+    // The cleanup between Strict Mode's two mount passes cancels playback via
+    // the hook's unmount effect. Without the remount branch's replay, playback
+    // stays dead and nothing reaches the engine afterwards.
+    //
+    // Asserting on ordering rather than on spoken() is deliberate: the fake's
+    // cancel() does not discard queued utterances the way a real engine does,
+    // so spoken() alone cannot tell a live utterance from a cancelled one.
+    await waitFor(() => expect(engine.spoken().length).toBeGreaterThanOrEqual(3));
+
+    const lastCancel = Math.max(...engine.cancel.mock.invocationCallOrder);
+    const spokenAfterCancel = engine.speak.mock.calls.some(
+      (call, index) =>
+        (call[0] as unknown as { text: string }).text.startsWith(
+          "Kernel 7.2 removes strncpy",
+        ) && engine.speak.mock.invocationCallOrder[index] > lastCancel,
+    );
+    expect(spokenAfterCancel).toBe(true);
+  });
+```
+
+In "stops feeding the speech engine once the page unmounts", the inline mock's
+chunks have no newlines, so under the new splitter nothing would ever be emitted
+and the `waitFor` would time out. Give them newlines and drop the count by one,
+since there is no longer a constructed opening ahead of them:
+
+```ts
+          async *[Symbol.asyncIterator]() {
+            yield "First sentence here.\n";
+            await gate;
+            yield "Late sentence arrives.\n";
+          },
+```
+
+```ts
+    const { unmount } = render(<AudioSummaryPlayer {...props} />);
+    await waitFor(() => expect(engine.spoken()).toHaveLength(1));
+```
+
+Add the new alert test at the end of the describe block:
+
+```ts
+  it("warns when no voice matches the article's language", async () => {
+    installSpeechEngine([{ name: "Test Voice", lang: "en-US" }]);
+
+    render(<AudioSummaryPlayer articleId={42} language="de" />);
+
+    expect(await screen.findByText(/no German voice/i)).toBeInTheDocument();
+    // The reader can still play it, knowing it will be mispronounced.
+    expect(screen.getByRole("button", { name: /pause|play/i })).toBeEnabled();
+  });
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run --project components` Expected: FAIL — the player still
+builds an opening line and takes the old props.
+
+- [ ] **Step 4: Update the player**
+
+In `src/components/article/audio-summary-player.tsx`:
+
+Replace the `buildOpeningLine` import with the splitter alone, and add the
+display-name helper:
+
+```ts
+import { splitIntoSentences } from "@/lib/audio-script";
+import { languageDisplayName } from "@/lib/language";
+```
+
+Replace the props interface:
+
+```ts
+interface AudioSummaryPlayerProps {
+  articleId: number;
+  language: string | null;
+}
+```
+
+Take `voiceAvailable` from the hook and pass it the language:
+
+```ts
+const {
+  activeIndex,
+  enqueue,
+  pause,
+  paused,
+  playFrom,
+  rate,
+  resume,
+  setRate,
+  speaking,
+  supported,
+  voiceAvailable,
+} = useSpeechSynthesis(props.language);
+```
+
+In the streaming effect, delete the two lines that build and append the opening:
+
+```ts
+// The opening needs no generation, so playback starts before the model has
+// returned anything — which also buys it a head start over the voice.
+append(buildOpeningLine(props.title, props.author, props.feedTitle));
+playFrom(0);
+```
+
+and replace them with:
+
+```ts
+// Marks playback active against an empty queue, so enqueue() hands each
+// sentence straight to the engine as it streams in. The introduction is
+// generated now, so nothing is audible until the first sentence lands.
+playFrom(0);
+```
+
+Update that effect's dependency array, which no longer reads the removed props:
+
+```ts
+  }, [props.articleId, enqueue, playFrom]);
+```
+
+Add the new alert directly below the existing `!supported` one:
+
+```tsx
+{
+  supported && !voiceAvailable && (
+    <Alert>
+      <AlertTitle>Voice unavailable</AlertTitle>
+      <AlertDescription>
+        No {languageDisplayName(props.language)} voice is installed in this
+        browser, so the briefing will be read with the default voice and
+        pronounced incorrectly. The transcript below is unaffected.
+      </AlertDescription>
+    </Alert>
+  );
+}
+```
+
+- [ ] **Step 5: Update the page**
+
+In `src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx`, replace
+the player element:
+
+```tsx
+<AudioSummaryPlayer articleId={article.id} language={article.language} />
+```
+
+Leave the `articleAuthor` import and the
+`<ArticleMeta author={articleAuthor(article)} />` above it alone — the page
+still renders the author itself.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `npx vitest run --project components` Expected: PASS.
+
+Run: `npx vitest run --project node tests/unit/audioSummaryPageLayout.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Full verification**
+
+Run: `npm run test` Expected: PASS, both projects.
+
+Run: `npm run lint` Expected: no errors.
+
+Run: `npm run build` Expected: build succeeds.
+
+Run: `npm run format:check` Expected: clean. If not, run `npm run format` and
+re-check.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/article/audio-summary-player.tsx "src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx" tests/components/article/audio-summary-player.test.tsx tests/unit/audioSummaryPageLayout.test.ts
+git commit -m "feat: warn when no voice is installed for a briefing's language"
+```
+
+---
+
+## Manual verification
+
+Automated tests mock every model call, so the prompts themselves are never
+exercised against a real model. Before opening the PR, check the behaviour end
+to end with a configured provider:
+
+1. Add a German-language feed (for example
+   `https://www.spiegel.de/schlagzeilen/tops/index.rss`) and let it refresh.
+2. Confirm the card's lead is German, and that the article row in the database
+   carries `language = 'de'`: `npx prisma studio` → Article → check `language`.
+3. Open the text summary. The bullets **and** the `###` heading should be
+   German.
+4. Open the audio summary. The transcript should open with a German introduction
+   naming the title and publication, each sentence on its own line, and — with a
+   German voice installed — be spoken in German. Without one, the "Voice
+   unavailable" alert should name German and playback should still be possible.
+5. Open any English article and confirm nothing about it reads differently,
+   other than the introduction now being generated rather than instant.
+
+## Finishing up
+
+Use the `superpowers:finishing-a-development-branch` skill. Per `AGENTS.md`:
+push `feat/article-language`, open a PR against `main` with `gh pr create`, wait
+for CI (`format-check`, `lint`, `test`, `build`), and leave the merge to the
+user unless they explicitly ask for it.

--- a/docs/superpowers/specs/2026-08-06-article-language-design.md
+++ b/docs/superpowers/specs/2026-08-06-article-language-design.md
@@ -1,0 +1,401 @@
+# Language-Aware Article Processing — Design
+
+Date: 2026-08-06
+
+## Summary
+
+Record the language of each article and state it explicitly in every prompt, so
+a German article produces a German lead, a German text summary, and a German
+audio briefing spoken by a German voice. The language is determined once, by the
+model, as structured output alongside the lead that is already generated for
+every article at ingest. It is stored on the article and read by everything
+downstream.
+
+## Motivation
+
+Nothing in the pipeline currently states what language the generated text should
+be in, so the model infers it from the source. The same feed can produce output
+in the article's language one day and in English the next.
+
+Read Aloud compounds this. `useSpeechSynthesis` never sets `utterance.lang` and
+never selects a voice, so the browser reads every briefing with its default —
+usually English — voice. A German briefing spoken with English phonetics is hard
+to follow. The spoken introduction assembled by `buildOpeningLine` is English by
+construction: "Written by …, from …".
+
+## Goals
+
+- A non-English article produces its lead, text summary, and audio briefing in
+  its own language.
+- The output language is a recorded property of the article, not something that
+  emerges from the model's guesswork.
+- Read Aloud pronounces a briefing in the language it is written in.
+
+## Non-goals
+
+- **Translating the application's interface.** Buttons, headings, navigation,
+  and error messages stay English. This feature is about the article's content,
+  not the reader's UI locale.
+- **A reader-facing language override.** Neither per-feed nor per-article.
+  Detection plus the English fallback is the whole story. If misdetection turns
+  out to be a real problem in practice, an override can be added then, informed
+  by actual cases rather than speculation.
+- **Backfilling existing articles.** Articles already stored have no language
+  and fall back to English. `ARTICLE_RETENTION_DAYS` is 30, so the gap closes on
+  its own within a month, which is not worth an operational step or a billable
+  pass over the corpus.
+- **Regenerating leads when a language is established later.** Does not arise,
+  given there is no backfill.
+- **Re-deriving the language on re-scrape.** A re-scrape does not regenerate the
+  lead — the card only generates when none exists — so the language is not
+  recomputed. This would only matter if an article changed language after
+  publication.
+- **Repairing or retrying malformed structured output.** See "Error handling".
+
+## Decisions and their alternatives
+
+**The model determines the language, not a detection library.** A statistical
+detector (tinyld, eld) would be offline, free, and would yield a confidence
+score. It was rejected in favour of reusing a call that already happens: lead
+generation runs for every article at ingest, so asking for the language as an
+additional structured-output field costs no extra request and no extra latency
+beyond the structured-output overhead. No new dependency.
+
+**The audio introduction is split: the title is constructed, everything after it
+is generated.** The connectives around a headline ("Written by …, from …") are
+the part that needs translating, so they are generated and read naturally in the
+article's own language rather than coming from a hand-maintained table. The
+headline itself is not: it is already known exactly, so `spokenTitle` emits it
+verbatim, which both removes any chance of the model paraphrasing or translating
+it and lets playback begin the moment the page opens rather than after the
+model's time-to-first-token.
+
+An earlier revision of this design generated the introduction in full and
+accepted losing that head start. Splitting at the title recovers it while
+keeping the benefit that motivated the change, so the briefing now opens
+instantly in every language.
+
+The generated part opens at the publication, and the prompt forbids openings
+that merely announce the article as an article — "The article titled…", "Der
+Artikel…" — since the listener has just heard the headline and such phrases
+carry no information.
+
+**The prompt states the language even when it is English.** The point is that
+the language is deliberate rather than inferred, which means it is stated in all
+cases. The observable output for an English article is unchanged; the prompt
+text is not byte-identical.
+
+## Establishing the language
+
+`Article` gains `language String?`. Null means "never established" and resolves
+to English everywhere it is read.
+
+`generateAiLead` in `src/lib/ai/services/leadService.ts` becomes the single
+point where language is determined. It swaps `generateText` for `generateObject`
+with a Zod schema:
+
+```ts
+z.object({
+  language: z
+    .string()
+    .describe(
+      'The article\'s language as a two-letter ISO 639-1 code, for example "de". ' +
+        'Use "und" — the standard code for "undetermined" — if the language cannot ' +
+        "be established.",
+    ),
+  lead: z.string(),
+});
+```
+
+`language` is declared **before** `lead` deliberately. Structured output is
+generated field by field, so the model commits to a language and then writes the
+lead in it, rather than reporting a language after the fact.
+
+`"und"` is the registered ISO 639-2/639-3 code for "undetermined" and a valid
+BCP-47 primary subtag. It exists purely to give the model a sanctioned way to
+report uncertainty rather than guessing between, say, Dutch and Afrikaans on a
+short article. Nothing downstream special-cases it: being three letters, it
+fails the two-letter rule in step 2 below and stores null, exactly as `"German"`
+and `"xx"` do. Because it is the one permitted value that is _not_ an ISO 639-1
+code, the schema description names it explicitly and explains what it means —
+otherwise "two letters, or this one three-letter word" reads as a contradiction
+and invites the model to substitute `"un"` or `"unknown"`.
+
+The returned value is normalised and validated by `src/lib/language.ts` before
+storage. The order of the checks is load-bearing:
+
+1. Lowercase and reduce to the primary subtag, so `"de-DE"` and `"de_DE"` become
+   `"de"`.
+2. Require exactly two letters (`/^[a-z]{2}$/`).
+3. Require that `Intl.DisplayNames(["en"], { type: "language" }).of(code)`
+   returns something other than the code itself — an unrecognised tag echoes
+   itself back, which is the check.
+
+Step 2 must precede step 3 for three verified reasons:
+
+- `.of("")` throws a `RangeError` rather than returning a value, so the regex is
+  what keeps the lookup safe.
+- `.of("deu")` returns "German" rather than echoing, so ISO 639-2 codes are
+  rejected by the length rule alone.
+- `.of("und")` returns **"root"** — the sentinel passes the recognition check.
+
+Reordering these would therefore admit both `"deu"` and the undetermined
+sentinel itself, storing them and setting them as `utterance.lang`, where no
+browser will match them against a voice. The length rule is the only thing that
+catches either.
+
+`"de-DE"` therefore survives as `"de"`; `"und"`, `"German"`, `"deu"`, `"xx"`,
+`"un"`, and `""` all store null.
+
+Storage is a single nested write, replacing the existing `articleLead.upsert`:
+
+```ts
+prisma.article.update({
+  where: { id: articleId },
+  data: { language, lead: { upsert: { create: { text }, update: { text } } } },
+});
+```
+
+One query, so the language cannot drift out of step with the lead it was
+determined alongside.
+
+## Reading the language
+
+`summaryService` and `audioScriptService` already load the article, so they read
+`article.language` directly — no query in the codebase needs a new `include` to
+find it. The audio summary page passes it to `AudioSummaryPlayer` as a prop.
+
+`audioScriptService` does need one `include` addition — `feed: true` — because
+the model now writes the introduction and needs the publication name. The author
+it passes to the prompt comes from `articleAuthor(article)`, the existing helper
+in `src/lib/article.ts`, so the feed-declared author continues to win over
+Readability's byline and no second notion of "the author" is introduced.
+
+## `src/lib/language.ts`
+
+A new module, shared by server and client:
+
+- the normalisation and validation described above;
+- `languageDisplayName("de") → "German"`, via `Intl.DisplayNames`;
+- the English default.
+
+`prompts.ts` imports it to build its directive; the audio player imports it to
+name a language in an alert.
+
+## Prompts
+
+`src/lib/ai/prompts.ts` gains a helper that renders a stored value as a
+directive — `"de"` becomes "Write entirely in German.", null becomes English.
+All three prompts embed it as the last instruction before the `<article>` block.
+Every `language` parameter below is `string | null`, matching the column.
+
+**`buildLeadPrompt(title, textContent)`** — signature unchanged. Rather than
+receiving a language it is told to determine one: report the article's language
+as an ISO 639-1 code, use `"und"` if genuinely unclear, and write the lead in
+that same language.
+
+**`buildSummaryPrompt(title, textContent, language)`** — gains the directive.
+The prompt names literal English headings ("Key Facts", "Key Takeaways", "Key
+Points"); these remain the _selection criteria_, with an added instruction to
+render the chosen heading in the output language, so a German summary is not a
+German bullet list under an English heading.
+
+**`buildAudioScriptPrompt({ title, author, feedTitle, textContent, language })`**
+— the larger rewrite. It takes a single object rather than five positional
+arguments, because four of the five are strings and three of those (`title`,
+`author`, `feedTitle`) are freely transposable at the call site without a type
+error. The clause stating the briefing "has already been introduced" is replaced
+by the introduction's requirements: open by announcing the article, reproducing
+the supplied title exactly and without paraphrase or translation, then the
+publication, and the author only when one is supplied. When no author is known
+the field is omitted from the prompt entirely, so there is nothing to invent
+from. The 150–200 word budget continues to describe the body, with the
+introduction on top.
+
+The prompt also instructs one sentence per line, a single newline between
+sentences, and no blank lines — worded so it does not read as licence to produce
+a bulleted list, given the same prompt forbids Markdown.
+
+`systemPrompt` is unchanged.
+
+## Sentence splitting
+
+Asking the model to delimit sentences with newlines removes the need to infer
+sentence boundaries from punctuation. `isSentenceEnd`, the `ABBREVIATIONS` set,
+and the decimal, ordinal, and initials special-casing in
+`src/lib/audio-script.ts` are all deleted. The German "z.B." problem — and the
+equivalent in every other language — stops existing rather than being
+generalised into per-language abbreviation tables. The delimiter also becomes
+unambiguous, so a sentence can be spoken as soon as its newline arrives, without
+the whitespace lookahead the current splitter needs to confirm a terminator.
+
+`splitIntoSentences` keeps its streaming contract —
+`(buffer) → { sentences, remainder }`, with the remainder fed back alongside the
+next delta — because deltas still arrive mid-line. Its body becomes a newline
+split.
+
+If the model ignores the instruction and emits no newlines, the whole briefing
+arrives as one utterance and runs into the roughly 15-second cut-off Chrome
+applies to a single long one. This is accepted rather than defended against: a
+length-based fallback was considered and rejected as not worth the complexity.
+
+`buildOpeningLine` is replaced by `spokenTitle`, which keeps only the part that
+still earns its place: terminating the headline as its own sentence. Headlines
+frequently end in "?" or "!", and neither replacing that terminator nor
+appending a second one reads correctly aloud. The author and publication
+connectives it used to assemble are now the model's job.
+
+## Speech playback
+
+`useSpeechSynthesis` takes the article's language (null → English) and changes
+in two ways.
+
+**Voice matching.** From `getVoices()`, the first voice whose primary subtag
+equals the article's language, tolerating both `de-DE` and `de_DE` since engines
+differ. The match is held in a ref, because utterances are created at `speak()`
+time as sentences stream in. `utterance.lang` is set unconditionally;
+`utterance.voice` only when a match exists, leaving the engine its own fallback
+otherwise.
+
+**A second support signal.** `supported` keeps its current meaning — whether
+there are any voices at all — and a new `voiceAvailable` reports whether one
+matches this language. Both are recomputed in the existing `voiceschanged`
+listener, since Chrome populates the voice list asynchronously.
+
+The player can then distinguish two failures that currently look alike:
+
+- No voices installed keeps today's "Playback unavailable" alert verbatim.
+- Voices present but none matching gets a new alert naming the language ("No
+  German voice is installed…"), with the transport controls left **enabled** so
+  the reader can play a mispronounced briefing knowingly.
+  `disabled={!supported}` stays keyed to `supported` alone.
+
+`AudioSummaryPlayer`'s props change shape: `author` and `feedTitle` go away,
+since the server action loads those itself for the generated part of the
+introduction, while `language` arrives and `title` stays. The mount effect
+enqueues `spokenTitle(title)` and then calls `playFrom(0)`, so audio begins
+immediately and `enqueue` hands each arriving sentence straight to the engine as
+it streams in.
+
+The title is enqueued directly rather than through the transcript's `append`,
+because the page heading immediately above the player already shows it — so
+playback index 0 has no transcript row, and the transcript's highlight maps
+display index `i` to playback index `i + 1`.
+
+The transcript renders one block per sentence rather than inline spans joined by
+spaces, so the line structure the model emits survives to the page, at
+`leading-loose`.
+
+Because the title is spoken from code, the play button showing "Pause" always
+corresponds to something audible from the first moment. The only remaining case
+where it does not is generation failing before any sentence arrives, which
+leaves `speaking` latched true; that is recorded in the code and accepted as
+cosmetic.
+
+## Error handling
+
+Nothing new is caught. Every new failure drains into a path that already exists.
+
+- **Invalid language code.** Normalised and validated as described above;
+  anything that fails stores null and resolves to English.
+- **Malformed structured output.** Genuinely new: `generateText` cannot fail
+  schema validation, `generateObject` can. It lands in the `try`/`catch` that
+  `processArticle` already wraps lead generation in — logged, article kept, no
+  lead, no language, English downstream. The same outcome as any of today's lead
+  failures, reached a new way.
+- **Lead generation failed or never ran.** Language stays null → English.
+- **Scrape failed.** `textContent` is `""` today and stays so; the model works
+  from the title alone and may record a language from it. A headline is usually
+  enough to distinguish German from English, and the fallback is English
+  regardless.
+- **Pre-existing articles.** Null language, English output, purged within 30
+  days.
+
+### Retry behaviour, and why nothing is added
+
+In `ai@7.0.44`, `generate-object.ts:398` wraps only `model.doGenerate()` in
+`retry(...)`. Parsing and validation run at line 470, outside that closure.
+Therefore:
+
+- **Transport failures are retried.** `maxRetries` defaults to `2`
+  (`prepare-retries.ts:35`), i.e. three attempts, with backoff starting at
+  2000ms and doubling, honouring `retry-after-ms` / `retry-after` headers within
+  0–60s. `shouldRetry` admits only `APICallError` or `GatewayError` with
+  `isRetryable === true` — rate limits and the 5xx class. `generateText` uses
+  the same wrapper today, so this is not a regression.
+- **Schema failures are not retried.** Unparseable JSON, or well-formed JSON
+  failing the Zod schema, throws `NoObjectGeneratedError` on the first attempt.
+  The only hook is `experimental_repairText`
+  (`parse-and-validate-object-result.ts:77`), which is `undefined` unless
+  supplied and otherwise rethrows.
+
+Neither a repair function nor a manual retry is added. The schema is two string
+fields and is passed to the provider as
+`responseFormat: { type: "json", schema }`, so providers with native structured
+output enforce it server-side rather than relying on model compliance. And the
+failure is survivable by construction: the reader gets a lead-less card, which
+is already what any lead failure produces today. This paragraph exists so a
+future reader does not assume the retry covers schema failures.
+
+## Observability
+
+The `logger.info` payload in all three services gains the language, so "why was
+this German article read in English" is answerable from the logs without
+reproducing it.
+
+## Testing
+
+Following the repo's existing split: the `node` project for unit and
+integration, `components` for jsdom.
+
+**New — `tests/unit/language.test.ts`.** `"de"` accepted and named "German";
+`"de-DE"`, `"de_DE"`, and `"DE"` normalised to `"de"`; `"und"`, `"German"`,
+`"deu"`, `"xx"`, `"un"`, and `""` rejected to null; null input resolving to
+English. `"und"` and `"deu"` are the load-bearing cases — both survive the
+`Intl.DisplayNames` check and are caught only by the length rule, so these tests
+are what stop a future reordering of the validation from regressing silently.
+
+**`tests/unit/prompts.test.ts`.** Summary prompt with `"de"` names German and
+carries the heading-translation instruction; with null it names English. Audio
+prompt includes title and feed title, includes the author when supplied, and
+omits the author element entirely when none is known — the structural guard
+against inventing one. Lead prompt asks for an ISO 639-1 code and offers
+`"und"`.
+
+**`tests/unit/audio-script.test.ts`.** `spokenTitle` gets: terminates a headline
+that lacks punctuation, leaves an existing `?`, `!`, or `.` alone, trims.
+`splitIntoSentences` gets: splits on newline, holds an unterminated remainder
+across successive deltas, ignores blank lines, and — the case that discriminates
+against the old punctuation splitter — keeps a sentence whole across `usw.`, a
+German abbreviation the old English list did not know.
+
+**`tests/integration/leadService.test.ts`.** The existing `vi.mock("ai", …)`
+moves from `generateText` to `generateObject` returning
+`{ object: { language, lead }, totalUsage }`. A valid code stores both lead and
+language; an invalid code stores the lead with a null language; `"und"` stores
+null; token usage is still recorded, since that path changes shape.
+
+**`tests/helpers/speech-synthesis.ts`.** `FakeUtterance` gains `lang` and
+`voice`; the fake voices gain `lang` values so matching can be exercised.
+
+**`tests/components/hooks/use-speech-synthesis.test.tsx`.** A `de-DE` voice
+present for a `de` article sets both `utterance.voice` and `utterance.lang`,
+with `voiceAvailable` true; `de_DE` matches too; only `en-US` voices present
+leaves `voice` unset with `supported` true and `voiceAvailable` false; no voices
+at all keeps `supported` false; voices arriving later through `voiceschanged`
+recompute the match.
+
+**`tests/components/article/audio-summary-player.test.tsx`.** Updated for the
+new props. No-matching-voice renders the alert naming German with transport
+controls still enabled; no-voices renders today's "Playback unavailable" alert;
+and a regression guard that nothing is spoken before the stream's first
+sentence, since the constructed opening line is gone.
+
+No e2e changes — the Playwright specs do not exercise generation.
+
+## Unrelated pre-existing failure
+
+`tests/integration/feedRepository.test.ts` fails `npx tsc --noEmit` on `main`:
+its `feedItem` factory is missing the `author` field added in d6d61c7. It does
+not gate `npm run build` and is not touched by this work. Noted so it is not
+mistaken for fallout.

--- a/prisma/migrations/20260806000000_add_article_language/migration.sql
+++ b/prisma/migrations/20260806000000_add_article_language/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN "language" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model Article {
   description     String?
   content         String?
   author          String?
+  language        String?
   link            String
   commentsLink    String?
   readAt          DateTime?

--- a/src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx
+++ b/src/app/feed/[feedId]/article/[articleId]/audio-summary/page.tsx
@@ -1,13 +1,11 @@
 "use server";
 
-import ArticleMeta from "@/components/article/article-meta";
 import AudioSummaryArticleActions from "@/components/article/audio-summary-article-actions";
 import AudioSummaryPlayer from "@/components/article/audio-summary-player";
 import IntlRelativeTime from "@/components/intl-relative-time";
 import BackButton from "@/components/navigation/back-button";
 import TopNavigation from "@/components/navigation/top-navigation";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { articleAuthor } from "@/lib/article";
 import { auth } from "@/lib/auth";
 import prisma from "@/lib/prismaClient";
 import { headers } from "next/headers";
@@ -63,12 +61,10 @@ const AudioSummary = async (props0: {
           </span>
         </div>
         <h2 className="text-2xl font-bold tracking-tight">{article.title}</h2>
-        <ArticleMeta author={articleAuthor(article)} />
         {article.scrape ? (
           <AudioSummaryPlayer
             articleId={article.id}
-            author={articleAuthor(article)}
-            feedTitle={article.feed.title}
+            language={article.language}
             title={article.title}
           />
         ) : (

--- a/src/components/article/audio-summary-player.tsx
+++ b/src/components/article/audio-summary-player.tsx
@@ -6,7 +6,8 @@ import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { useSpeechSynthesis } from "@/hooks/use-speech-synthesis";
 import { streamAudioScript } from "@/lib/ai/services/audioScriptService";
-import { buildOpeningLine, splitIntoSentences } from "@/lib/audio-script";
+import { splitIntoSentences, spokenTitle } from "@/lib/audio-script";
+import { languageDisplayName } from "@/lib/language";
 import { readStreamableValue } from "@ai-sdk/rsc";
 import { PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -19,8 +20,7 @@ const MAX_RATE = 2;
 
 interface AudioSummaryPlayerProps {
   articleId: number;
-  author: string | null | undefined;
-  feedTitle: string;
+  language: string | null;
   title: string;
 }
 
@@ -36,7 +36,8 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
     setRate,
     speaking,
     supported,
-  } = useSpeechSynthesis();
+    voiceAvailable,
+  } = useSpeechSynthesis(props.language);
   // The hook keeps its own copy of the sentences for playback, but that copy is
   // a ref and cannot drive rendering. This one is for display.
   const [sentences, setSentences] = useState<string[]>([]);
@@ -49,13 +50,6 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
   // restored from localStorage show up on mount.
   const [draggedRate, setDraggedRate] = useState<number | undefined>(undefined);
   const initialized = useRef(false);
-  // Strict Mode double-invokes mount effects in development. setRate() calls
-  // playFrom() when playback is already under way, so a second invocation of
-  // this effect while the streaming effect's playFrom(0) is in flight would
-  // cancel and re-speak the whole queue from the top. Guard with its own ref,
-  // separate from `initialized`, so each effect's guard stays readable on its
-  // own.
-  const restoredRate = useRef(false);
   // Set by the streaming effect's cleanup so the in-flight `for await` loop
   // stops feeding the speech engine once this instance is torn down. See the
   // comment where it is reset, inside the effect.
@@ -64,9 +58,6 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
   // Read the saved rate in an effect rather than during render, so the server
   // and the first client render agree on the 1.0x default.
   useEffect(() => {
-    if (restoredRate.current) return;
-    restoredRate.current = true;
-
     const stored = Number(window.localStorage.getItem(RATE_STORAGE_KEY));
     if (stored >= MIN_RATE && stored <= MAX_RATE) {
       setRate(stored);
@@ -91,8 +82,10 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
     if (initialized.current) {
       // Strict Mode double-invokes mount effects in development, and the
       // cleanup between the two runs cancels playback through the hook's
-      // unmount effect — which would otherwise silence the opening line for
-      // good, since the guard below stops it being enqueued again. Every
+      // unmount effect — which calls speechSynthesis.cancel() directly,
+      // leaving the engine's paused flag latched. playFrom() is what clears
+      // it, via its explicit resume(); without this replay every later
+      // utterance would be handed to an engine that stays silent. Every
       // sentence is still retained by the hook, so replaying costs nothing
       // and generates nothing.
       playFrom(0);
@@ -108,9 +101,13 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
       enqueue(sentence);
     };
 
-    // The opening needs no generation, so playback starts before the model has
-    // returned anything — which also buys it a head start over the voice.
-    append(buildOpeningLine(props.title, props.author, props.feedTitle));
+    // The title needs no generation, so playback starts the moment the page
+    // opens rather than waiting on the model's first token — and the headline
+    // is spoken exactly as written instead of however the model paraphrased
+    // it. Enqueued directly rather than through append(): the transcript
+    // covers the generated briefing only, since the page heading right above
+    // already shows the title. That offset is undone where sentences render.
+    enqueue(spokenTitle(props.title));
     playFrom(0);
 
     const streamScript = async () => {
@@ -125,7 +122,7 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
           complete.forEach(append);
         }
 
-        // A stream often ends without terminal punctuation, so whatever is left
+        // A stream often ends without a trailing newline, so whatever is left
         // is spoken as a final sentence.
         if (buffer.trim()) {
           append(buffer.trim());
@@ -133,6 +130,13 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
       } catch {
         // Whatever already streamed keeps playing — only the rest of the
         // script failed to arrive. Surface that without touching playback.
+        //
+        // Known cosmetic gap: if this throws before any sentence has
+        // arrived, nothing was ever queued, so the hook's handleDone never
+        // runs and `speaking` stays true — the button reads "Pause" forever
+        // beside the "Briefing incomplete" alert. Not worth an unconditional
+        // cancel() here, since that would also cut off sentences that did
+        // stream successfully before the failure.
         setGenerationFailed(true);
       }
     };
@@ -144,14 +148,7 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
     };
     // Guarded by initialized.current above, so this effect behaves as a
     // mount-only effect despite the honest dependency array.
-  }, [
-    props.articleId,
-    props.title,
-    props.author,
-    props.feedTitle,
-    enqueue,
-    playFrom,
-  ]);
+  }, [props.articleId, props.title, enqueue, playFrom]);
 
   const togglePlayback = () => {
     if (paused) return resume();
@@ -184,6 +181,17 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
         </Alert>
       )}
 
+      {supported && !voiceAvailable && (
+        <Alert>
+          <AlertTitle>Voice unavailable</AlertTitle>
+          <AlertDescription>
+            No {languageDisplayName(props.language)} voice is installed in this
+            browser, so the briefing will be read with the default voice and
+            pronounced incorrectly. The transcript below is unaffected.
+          </AlertDescription>
+        </Alert>
+      )}
+
       {generationFailed && (
         <Alert>
           <AlertTitle>Briefing incomplete</AlertTitle>
@@ -194,17 +202,22 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
         </Alert>
       )}
 
-      <p className="text-lg leading-relaxed text-pretty">
+      {/* One block per sentence, so the line structure the model emits
+          survives to the page instead of being reflowed into a paragraph. */}
+      <div className="leading-loose text-pretty">
         {sentences.map((sentence, index) => (
-          <span
+          <p
             key={index}
-            data-active={index === activeIndex}
+            // The hook also retains the spoken title at playback index 0,
+            // which the transcript omits, so display index i is playback
+            // index i + 1.
+            data-active={index + 1 === activeIndex}
             className="data-[active=true]:bg-primary/15 rounded transition-colors"
           >
-            {sentence}{" "}
-          </span>
+            {sentence}
+          </p>
         ))}
-      </p>
+      </div>
 
       <div className="flex flex-wrap items-center gap-4 border-t pt-4">
         <Button

--- a/src/hooks/use-speech-synthesis.ts
+++ b/src/hooks/use-speech-synthesis.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LANGUAGE } from "@/lib/language";
 import * as React from "react";
 
 interface SpeechSynthesisControls {
@@ -12,7 +13,14 @@ interface SpeechSynthesisControls {
   setRate: (rate: number) => void;
   speaking: boolean;
   supported: boolean;
+  voiceAvailable: boolean;
 }
+
+// `speechSynthesis` is a single global shared by every instance of this hook,
+// so exactly one of them may own it at a time. Module scope rather than a ref
+// because the point is coordination *between* instances during the overlap a
+// client-side navigation creates.
+let engineOwner: symbol | undefined;
 
 // Centralizes the "does this environment even have the API" check so
 // playFrom(), cancel(), pause(), resume(), and speakSentence() do not each
@@ -36,8 +44,11 @@ const speechEngine = () =>
  * Only one audio surface is mounted at a time, so this needs none of the
  * cross-component arbitration a per-card version would.
  */
-export function useSpeechSynthesis(): SpeechSynthesisControls {
+export function useSpeechSynthesis(
+  language: string | null,
+): SpeechSynthesisControls {
   const [supported, setSupported] = React.useState(false);
+  const [voiceAvailable, setVoiceAvailable] = React.useState(false);
   const [speaking, setSpeaking] = React.useState(false);
   const [paused, setPaused] = React.useState(false);
   const [activeIndex, setActiveIndex] = React.useState<number | undefined>(
@@ -51,6 +62,18 @@ export function useSpeechSynthesis(): SpeechSynthesisControls {
   const playing = React.useRef(false);
   const rateValue = React.useRef(1);
   const activeIndexValue = React.useRef<number | undefined>(undefined);
+
+  // Identifies this instance for the engine-ownership check below. A ref so
+  // it survives Strict Mode's remount, which reuses the same instance.
+  const ownerToken = React.useRef<symbol>(undefined as unknown as symbol);
+  ownerToken.current ??= Symbol("speech-engine-owner");
+
+  // Resolved once here so every utterance and the voice lookup agree on it.
+  const spokenLanguage = language ?? DEFAULT_LANGUAGE;
+
+  // Read at speak() time rather than through state, because sentences are
+  // handed to the engine as they stream in, outside a render.
+  const voice = React.useRef<SpeechSynthesisVoice | undefined>(undefined);
 
   // Incremented whenever the engine queue is discarded. cancel() makes the
   // engine fire onend for every pending utterance, so handlers compare against
@@ -71,15 +94,27 @@ export function useSpeechSynthesis(): SpeechSynthesisControls {
     // getVoices() is populated asynchronously in Chrome, so an empty list only
     // means "no voices" after voiceschanged has fired. Linux without
     // speech-dispatcher installed never reports any.
-    const syncSupport = () =>
-      setSupported(window.speechSynthesis.getVoices().length > 0);
+    const syncVoices = () => {
+      const voices = window.speechSynthesis.getVoices();
+      setSupported(voices.length > 0);
 
-    syncSupport();
-    window.speechSynthesis.addEventListener("voiceschanged", syncSupport);
+      // Engines disagree on the separator. Browsers report the BCP-47 form
+      // ("de-DE"), while some Linux speech backends surface a POSIX locale
+      // ("de_DE") instead.
+      const match = voices.find(
+        (candidate) =>
+          candidate.lang?.toLowerCase().split(/[-_]/)[0] === spokenLanguage,
+      );
+      voice.current = match;
+      setVoiceAvailable(match !== undefined);
+    };
+
+    syncVoices();
+    window.speechSynthesis.addEventListener("voiceschanged", syncVoices);
 
     return () =>
-      window.speechSynthesis?.removeEventListener("voiceschanged", syncSupport);
-  }, []);
+      window.speechSynthesis?.removeEventListener("voiceschanged", syncVoices);
+  }, [spokenLanguage]);
 
   const speakSentence = React.useCallback(
     (index: number, forGeneration: number) => {
@@ -88,6 +123,13 @@ export function useSpeechSynthesis(): SpeechSynthesisControls {
 
       const utterance = new SpeechSynthesisUtterance(sentences.current[index]);
       utterance.rate = rateValue.current;
+      utterance.lang = spokenLanguage;
+
+      // Assigned only when a match exists: handing the engine an undefined
+      // voice is not the same as leaving it to pick its own default.
+      if (voice.current) {
+        utterance.voice = voice.current;
+      }
 
       utterance.onstart = () => {
         if (generation.current !== forGeneration) return;
@@ -115,7 +157,7 @@ export function useSpeechSynthesis(): SpeechSynthesisControls {
 
       engine.speak(utterance);
     },
-    [],
+    [spokenLanguage],
   );
 
   const playFrom = React.useCallback(
@@ -228,14 +270,24 @@ export function useSpeechSynthesis(): SpeechSynthesisControls {
     [playFrom],
   );
 
-  // Stop playback when the page goes away. Only one audio surface is ever
-  // mounted, so this cancels unconditionally.
-  React.useEffect(
-    () => () => {
+  // Stop playback when the page goes away — but only while this instance is
+  // still the engine's owner.
+  //
+  // Router navigations commit inside a transition, so the outgoing page's
+  // cleanup can run *after* the incoming page has mounted and queued its
+  // first utterance. Cancelling unconditionally then silences the new page's
+  // opening line while everything it streams later survives, because those
+  // arrive well after the stale cleanup. Claiming ownership on mount and
+  // checking it on cleanup fixes the ordering rather than racing it.
+  React.useEffect(() => {
+    engineOwner = ownerToken.current;
+
+    return () => {
+      if (engineOwner !== ownerToken.current) return;
+      engineOwner = undefined;
       window.speechSynthesis?.cancel();
-    },
-    [],
-  );
+    };
+  }, []);
 
   return {
     activeIndex,
@@ -249,5 +301,6 @@ export function useSpeechSynthesis(): SpeechSynthesisControls {
     setRate,
     speaking,
     supported,
+    voiceAvailable,
   };
 }

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,19 +1,21 @@
+import { languageDisplayName } from "@/lib/language";
+
+/**
+ * The instruction that makes the output language deliberate rather than
+ * inferred. Stated even when the language is English: the point is that every
+ * generation is told what to write in, not that non-English is special-cased.
+ */
+const languageDirective = (language: string | null) =>
+  `Write entirely in ${languageDisplayName(language)}.`;
+
 export const systemPrompt =
   "You are a professional news editor writing article previews for a time-pressed professional readership. Write in a neutral, factual tone. Do not editorialize, express opinions, or draw conclusions not explicitly stated in the source material.";
-
-export const buildSummaryPrompt = (title: string, textContent: string) =>
-  `Write a summary using the following Markdown structure: Use a level 3 heading (###) titled "Key Facts" for news and factual reporting, "Key Takeaways" for opinion or commentary, or "Key Points" if the article type is unclear. Follow the heading with a bullet list of 5–12 bullets — fewer for short or focused articles, more for complex ones. Each bullet must be one concise sentence. Bold the single most important named entity, concept, or figure in each bullet.
-
-<article>
-<title>${title}</title>
-<content>
-${textContent}
-</content>
-</article>`;
 
 export const buildLeadPrompt = (title: string, textContent: string) =>
   `Write a single paragraph summarizing what the article covers and why it is significant or timely. Be factual and objective. The summary must be no longer than 80 words. Do not copy the article's opening lines verbatim, and do not add introductory phrases, headings, or filler.
 
+First determine the language the article is written in and report it as a two-letter ISO 639-1 code, for example "de" for German. If the language cannot be established, report "und". Write the lead in the language you reported.
+
 <article>
 <title>${title}</title>
 <content>
@@ -21,16 +23,66 @@ ${textContent}
 </content>
 </article>`;
 
-export const buildAudioScriptPrompt = (title: string, textContent: string) =>
-  `Write the body of a spoken audio briefing that a text-to-speech voice will read aloud. The briefing has already been introduced with the article's title, author, and publication, so do not restate any of them and do not open with a greeting.
+export const buildSummaryPrompt = (
+  title: string,
+  textContent: string,
+  language: string | null,
+) =>
+  `Write a summary using the following Markdown structure: Use a level 3 heading (###) titled "Key Facts" for news and factual reporting, "Key Takeaways" for opinion or commentary, or "Key Points" if the article type is unclear. Follow the heading with a bullet list of 5–12 bullets — fewer for short or focused articles, more for complex ones. Each bullet must be one concise sentence. Bold the single most important named entity, concept, or figure in each bullet.
 
-Write 150 to 200 words of continuous prose — roughly one minute of speech. Use short declarative sentences. Connect them with explicit transitions so the briefing flows when heard rather than read. Write numbers, symbols, and units the way they are spoken, for example "forty percent" rather than "40%". Avoid parenthetical asides, which cannot be heard.
+${languageDirective(language)} The heading names above are given in English; translate the one you choose into that language.
+
+<article>
+<title>${title}</title>
+<content>
+${textContent}
+</content>
+</article>`;
+
+/**
+ * Takes an object rather than positional arguments: four of the five fields
+ * are strings, and three of those are freely transposable at a call site
+ * without a type error.
+ */
+export const buildAudioScriptPrompt = ({
+  title,
+  author,
+  feedTitle,
+  textContent,
+  language,
+}: {
+  title: string;
+  author: string | null;
+  feedTitle: string;
+  textContent: string;
+  language: string | null;
+}) => {
+  // Omitted rather than left empty when unknown, so there is nothing in the
+  // prompt for the model to invent an author from.
+  const authorInstruction = author
+    ? "naming the publication and the author"
+    : "naming the publication — no author is known, so do not mention one";
+  const authorElement = author ? `<author>${author}</author>\n` : "";
+
+  return `Write a spoken audio briefing that a text-to-speech voice will read aloud.
+
+The article's title has already been spoken aloud before your text begins. Never repeat, paraphrase, translate, or refer back to it. It appears below only as context for writing the body — treat it as already said.
+
+Your first sentence must therefore be a single sentence ${authorInstruction}, phrased the way it would be said aloud. Then go straight into the briefing itself. Do not open with a greeting, and do not begin with a phrase that announces the article as an article — "The article titled", "This piece", "Der Artikel", or any equivalent. The listener has just heard the headline, so such openings carry no information.
+
+After the introduction, write 150 to 200 words of continuous prose — roughly one minute of speech. Use short declarative sentences. Connect them with explicit transitions so the briefing flows when heard rather than read. Write numbers, symbols, and units the way they are spoken, for example "forty percent" rather than "40%". Avoid parenthetical asides, which cannot be heard.
+
+Put each sentence on its own line, separated by a single newline. Do not leave blank lines between sentences.
 
 Output plain text only. Do not use Markdown, headings, bullet lists, bold, or italics.
 
+${languageDirective(language)}
+
 <article>
 <title>${title}</title>
+${authorElement}<publication>${feedTitle}</publication>
 <content>
 ${textContent}
 </content>
 </article>`;
+};

--- a/src/lib/ai/services/audioScriptService.ts
+++ b/src/lib/ai/services/audioScriptService.ts
@@ -2,6 +2,7 @@
 
 import { buildAudioScriptPrompt, systemPrompt } from "@/lib/ai/prompts";
 import { getFirstConfiguredLanguageModel } from "@/lib/ai/registry";
+import { articleAuthor } from "@/lib/article";
 import logger from "@/lib/logger";
 import prisma from "@/lib/prismaClient";
 import { getUserId } from "@/lib/repository/userRepository";
@@ -16,7 +17,7 @@ export const streamAudioScript = async (articleId: number) => {
 
   const article = await prisma.article.findUniqueOrThrow({
     where: { id: articleId, userId },
-    include: { scrape: true },
+    include: { feed: true, scrape: true },
   });
 
   const stream = createStreamableValue("");
@@ -25,10 +26,15 @@ export const streamAudioScript = async (articleId: number) => {
     const { textStream, totalUsage } = streamText({
       model,
       system: systemPrompt,
-      prompt: buildAudioScriptPrompt(
-        article.title,
-        article.scrape?.textContent ?? "",
-      ),
+      prompt: buildAudioScriptPrompt({
+        title: article.title,
+        // The existing helper, so the feed-declared author keeps winning over
+        // Readability's byline and no second notion of "the author" appears.
+        author: articleAuthor(article),
+        feedTitle: article.feed.title,
+        textContent: article.scrape?.textContent ?? "",
+        language: article.language,
+      }),
     });
 
     for await (const delta of textStream) {
@@ -43,6 +49,7 @@ export const streamAudioScript = async (articleId: number) => {
       {
         articleId,
         feedId: article.feedId,
+        language: article.language,
         model: model.modelId,
         tokenUsage,
       },

--- a/src/lib/ai/services/leadService.ts
+++ b/src/lib/ai/services/leadService.ts
@@ -2,12 +2,33 @@
 
 import { buildLeadPrompt, systemPrompt } from "@/lib/ai/prompts";
 import { getFirstConfiguredLanguageModel } from "@/lib/ai/registry";
+import { normalizeLanguage } from "@/lib/language";
 import logger from "@/lib/logger";
 import prisma from "@/lib/prismaClient";
-import { generateText } from "ai";
+import { generateObject } from "ai";
+import { z } from "zod";
 import { trackTokenUsage } from "./tokenUsageService";
 
 const model = await getFirstConfiguredLanguageModel();
+
+// `language` is declared before `lead` deliberately. Structured output is
+// generated field by field, so the model commits to a language and then writes
+// the lead in it, rather than reporting one after the fact.
+//
+// "und" is the registered code for "undetermined". It is described explicitly
+// because it is the one permitted value that is not an ISO 639-1 code —
+// "two letters, or this one three-letter word" otherwise reads as a
+// contradiction and invites "un" or "unknown" instead. Nothing special-cases
+// it downstream: normalizeLanguage rejects it on length, like any other
+// unusable value.
+const leadSchema = z.object({
+  language: z
+    .string()
+    .describe(
+      'The article\'s language as a two-letter ISO 639-1 code, for example "de". Use "und" — the standard code for "undetermined" — if the language cannot be established.',
+    ),
+  lead: z.string(),
+});
 
 export const generateAiLead = async (articleId: number) => {
   const article = await prisma.article.findUniqueOrThrow({
@@ -15,39 +36,47 @@ export const generateAiLead = async (articleId: number) => {
     where: { id: articleId },
   });
 
-  const lead = await generateText({
+  const { object, usage } = await generateObject({
     model,
+    schema: leadSchema,
     system: systemPrompt,
     prompt: buildLeadPrompt(article.title, article.scrape?.textContent ?? ""),
   });
 
-  await prisma.articleLead.upsert({
-    where: { articleId },
-    create: {
-      articleId,
-      text: lead.text,
-    },
-    update: {
-      text: lead.text,
+  const language = normalizeLanguage(object.language);
+
+  // One nested write, so the language cannot drift out of step with the lead
+  // it was determined alongside.
+  await prisma.article.update({
+    where: { id: articleId },
+    data: {
+      language,
+      lead: {
+        upsert: {
+          create: { text: object.lead },
+          update: { text: object.lead },
+        },
+      },
     },
   });
 
   await trackTokenUsage(
     article.userId,
     model.modelId,
-    lead.totalUsage.inputTokens ?? 0,
-    lead.totalUsage.outputTokens ?? 0,
+    usage.inputTokens ?? 0,
+    usage.outputTokens ?? 0,
   );
 
   logger.info(
     {
       articleId,
       feedId: article.feedId,
+      language,
       model: model.modelId,
-      tokenUsage: lead.totalUsage,
+      tokenUsage: usage,
     },
     "AI lead generated.",
   );
 
-  return lead.text;
+  return object.lead;
 };

--- a/src/lib/ai/services/summaryService.ts
+++ b/src/lib/ai/services/summaryService.ts
@@ -28,6 +28,7 @@ export const streamAiSummary = async (articleId: number) => {
       prompt: buildSummaryPrompt(
         article.title,
         article.scrape?.textContent ?? "",
+        article.language,
       ),
     });
 
@@ -43,6 +44,7 @@ export const streamAiSummary = async (articleId: number) => {
       {
         articleId,
         feedId: article.feedId,
+        language: article.language,
         model: model.modelId,
         tokenUsage,
       },

--- a/src/lib/audio-script.ts
+++ b/src/lib/audio-script.ts
@@ -1,130 +1,52 @@
 /**
- * Words that end in a period without ending a sentence. Lowercased, without
- * the trailing period.
+ * The article's headline as it should be spoken, terminated as its own
+ * sentence.
+ *
+ * Constructed rather than generated. The title is already known exactly, so
+ * involving the model could only risk it paraphrasing or translating the
+ * headline — and speaking it from code means playback starts the moment the
+ * page opens, without waiting on the model's first token. The generated script
+ * picks up from the publication onwards.
+ *
+ * Headlines frequently end in "?" or "!". Replacing that with a period would
+ * change how the voice reads the line, and appending one after it reads as an
+ * audible stumble, so an existing terminator is left alone.
  */
-const ABBREVIATIONS = new Set([
-  "mr",
-  "mrs",
-  "ms",
-  "dr",
-  "prof",
-  "sr",
-  "jr",
-  "st",
-  "vs",
-  "etc",
-  "eg",
-  "ie",
-  "approx",
-  "inc",
-  "ltd",
-  "co",
-  "fig",
-]);
-
-const isSentenceEnd = (buffer: string, index: number): boolean => {
-  const character = buffer[index];
-  if (character !== "." && character !== "!" && character !== "?") {
-    return false;
-  }
-
-  // A terminator only counts once the following character confirms it. Without
-  // this, a buffer ending in "3." would split a decimal that has not finished
-  // arriving. The caller flushes whatever remains when the stream closes.
-  if (!/\s/.test(buffer[index + 1] ?? "")) {
-    return false;
-  }
-
-  if (character !== ".") {
-    return true;
-  }
-
-  // An ellipsis is a pause inside a sentence, not the end of one.
-  if (buffer[index - 1] === ".") {
-    return false;
-  }
-
-  const precedingWord = /([A-Za-z]+)$/.exec(buffer.slice(0, index))?.[1];
-  if (!precedingWord) {
-    return true;
-  }
-
-  // A single letter before a period is an initial or part of an acronym:
-  // "U.S.", "J. R. R. Tolkien".
-  if (precedingWord.length === 1) {
-    return false;
-  }
-
-  // An ordinal number (1st, 21st, etc.) is a real sentence end, not an abbreviation.
-  // The letter-run regex yields just the letters ("st" from "1st"), so check if a
-  // digit precedes the word. If there is, it is an ordinal and ends the sentence.
-  const characterBeforeWord = buffer[index - precedingWord.length - 1];
-  if (/\d/.test(characterBeforeWord)) {
-    return true;
-  }
-
-  return !ABBREVIATIONS.has(precedingWord.toLowerCase());
+export const spokenTitle = (title: string): string => {
+  const trimmed = title.trim();
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
 };
 
 /**
- * Splits a buffer into complete sentences plus whatever is left over. Safe to
- * call repeatedly against a growing stream: feed the remainder back in with the
- * next delta appended.
+ * Splits a buffer into complete sentences plus whatever is left over.
+ *
+ * The audio script prompt asks the model to put each sentence on its own line,
+ * so the delimiter is a newline rather than something inferred from
+ * punctuation. That keeps this free of language-specific knowledge: an English
+ * abbreviation list would mis-split German ("z.B.") and every other language in
+ * its own way.
+ *
+ * If the model ignores the instruction and emits no newlines at all, the whole
+ * briefing arrives as a single utterance. Chrome truncates one of those at
+ * roughly 15 seconds; Firefox does not, so the consequence depends on the
+ * listener's browser. Either way it is accepted rather than defended against —
+ * see the design's note on the rejected length fallback.
+ *
+ * Safe to call repeatedly against a growing stream: feed the remainder back in
+ * with the next delta appended.
  */
 export const splitIntoSentences = (
   buffer: string,
 ): { sentences: string[]; remainder: string } => {
-  const sentences: string[] = [];
-  let start = 0;
+  const lines = buffer.split("\n");
 
-  for (let index = 0; index < buffer.length; index++) {
-    if (!isSentenceEnd(buffer, index)) {
-      continue;
-    }
+  // Whatever follows the final newline is a sentence the stream has not
+  // finished delivering. It is left untrimmed because the caller appends the
+  // next delta directly to it.
+  const remainder = lines.pop() ?? "";
 
-    const sentence = buffer.slice(start, index + 1).trim();
-    if (sentence) {
-      sentences.push(sentence);
-    }
-    start = index + 1;
-  }
-
-  // trimStart() only: the caller feeds this remainder back with the next
-  // delta appended, so a trailing space here is a real separator between two
-  // words that have not both arrived yet. Trimming it away glues them
-  // together. The leading trim is still wanted — it strips the space that
-  // followed a terminator.
-  return { sentences, remainder: buffer.slice(start).trimStart() };
-};
-
-/**
- * Builds the spoken introduction. This is constructed rather than generated:
- * the title, author, and feed are already known, so involving the model would
- * only risk it paraphrasing the title or inventing an author.
- *
- * The author is spoken verbatim. Readability's byline is unreliable, but
- * cleaning it up here would create a second place that knows how to tidy
- * bylines and make the real fix harder — see the design's non-goals.
- */
-export const buildOpeningLine = (
-  title: string,
-  author: string | null | undefined,
-  feedTitle: string,
-): string => {
-  const trimmedTitle = title.trim();
-
-  // The title terminates as its own sentence. Headlines frequently end in "?"
-  // or "!", and running those into a comma reads as an audible glitch.
-  const introduction = /[.!?]$/.test(trimmedTitle)
-    ? trimmedTitle
-    : `${trimmedTitle}.`;
-
-  // The scraper stores "" when Readability finds no byline. Without this
-  // branch the line would read "Written by , from Hacker News".
-  const trimmedAuthor = author?.trim();
-  if (!trimmedAuthor) {
-    return `${introduction} From ${feedTitle}.`;
-  }
-
-  return `${introduction} Written by ${trimmedAuthor}, from ${feedTitle}.`;
+  return {
+    sentences: lines.map((line) => line.trim()).filter((line) => line !== ""),
+    remainder,
+  };
 };

--- a/src/lib/language.ts
+++ b/src/lib/language.ts
@@ -1,0 +1,45 @@
+/**
+ * The language an article's generated text is written in.
+ *
+ * The model reports a language alongside the lead it generates (see
+ * leadService). Only values that survive `normalizeLanguage` are stored, and a
+ * null language means "never established", which resolves to English wherever
+ * it is read.
+ */
+
+export const DEFAULT_LANGUAGE = "en";
+
+const languageNames = new Intl.DisplayNames(["en"], { type: "language" });
+
+/**
+ * Reduces a model-supplied language to a storable ISO 639-1 code, or null.
+ *
+ * The order of the checks is load-bearing:
+ *
+ * - `Intl.DisplayNames.of("")` throws a RangeError rather than returning a
+ *   value, so the shape check is what keeps the lookup below safe.
+ * - `.of("deu")` returns "German" and `.of("und")` returns "root", so neither
+ *   ISO 639-2 codes nor the undetermined sentinel are caught by the
+ *   recognition check. The two-letter rule is the only thing that rejects
+ *   them. Reordering these would store both — and set them as
+ *   `utterance.lang`, where no browser matches them to a voice.
+ */
+export const normalizeLanguage = (
+  value: string | null | undefined,
+): string | null => {
+  const code = value?.trim().toLowerCase().split(/[-_]/)[0] ?? "";
+
+  if (!/^[a-z]{2}$/.test(code)) {
+    return null;
+  }
+
+  // A well-formed but unrecognised tag echoes itself back.
+  return languageNames.of(code) === code ? null : code;
+};
+
+/**
+ * The English name of a language, for prompt directives and reader-facing
+ * copy. The interface is English, so the names are too.
+ */
+export const languageDisplayName = (language: string | null): string =>
+  languageNames.of(language ?? DEFAULT_LANGUAGE) ?? "English";

--- a/tests/components/article/audio-summary-player.test.tsx
+++ b/tests/components/article/audio-summary-player.test.tsx
@@ -13,11 +13,16 @@ vi.mock("@/lib/ai/services/audioScriptService", () => ({
 vi.mock("@ai-sdk/rsc", () => ({
   readStreamableValue: vi.fn(() => ({
     async *[Symbol.asyncIterator]() {
-      yield "It landed after 362 patches. ";
+      yield "Published at Hacker News, written by Jane Doe.\n";
+      yield "It landed after 362 patches.\n";
       yield "Maintainers had warned for years.";
     },
   })),
 }));
+
+// The title is spoken from code, so it leads the playback queue while being
+// absent from the transcript.
+const SPOKEN_TITLE = "Kernel 7.2 removes strncpy.";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -26,20 +31,41 @@ afterEach(() => {
 
 const props = {
   articleId: 42,
+  language: "en",
   title: "Kernel 7.2 removes strncpy",
-  author: "Jane Doe",
-  feedTitle: "Hacker News",
 };
 
 describe("AudioSummaryPlayer", () => {
-  it("speaks the constructed opening before any generated text arrives", () => {
+  it("speaks the title at mount, before the model has returned anything", () => {
     const engine = installSpeechEngine();
 
     render(<AudioSummaryPlayer {...props} />);
 
-    expect(engine.spoken()[0].text).toBe(
-      "Kernel 7.2 removes strncpy. Written by Jane Doe, from Hacker News.",
+    // Synchronous with render: the title needs no generation, so audio starts
+    // without waiting on the model's first token.
+    expect(engine.spoken().map((utterance) => utterance.text)).toEqual([
+      SPOKEN_TITLE,
+    ]);
+  });
+
+  it("terminates the spoken title so it does not run into the next sentence", () => {
+    const engine = installSpeechEngine();
+
+    render(
+      <AudioSummaryPlayer title="Is Rust dead?" articleId={42} language="en" />,
     );
+
+    expect(engine.spoken()[0].text).toBe("Is Rust dead?");
+  });
+
+  it("keeps the title out of the transcript", async () => {
+    installSpeechEngine();
+
+    render(<AudioSummaryPlayer {...props} />);
+
+    // The page heading above the player already shows it.
+    await screen.findByText(/It landed after 362 patches\./);
+    expect(screen.queryByText(SPOKEN_TITLE)).not.toBeInTheDocument();
   });
 
   it("speaks each generated sentence as it streams in", async () => {
@@ -49,7 +75,8 @@ describe("AudioSummaryPlayer", () => {
 
     await waitFor(() =>
       expect(engine.spoken().map((utterance) => utterance.text)).toEqual([
-        "Kernel 7.2 removes strncpy. Written by Jane Doe, from Hacker News.",
+        SPOKEN_TITLE,
+        "Published at Hacker News, written by Jane Doe.",
         "It landed after 362 patches.",
         "Maintainers had warned for years.",
       ]),
@@ -70,9 +97,11 @@ describe("AudioSummaryPlayer", () => {
     const engine = installSpeechEngine();
 
     render(<AudioSummaryPlayer {...props} />);
-    await waitFor(() => expect(engine.spoken()).toHaveLength(3));
+    await waitFor(() => expect(engine.spoken()).toHaveLength(4));
 
-    engine.spoken()[1].onstart!();
+    // Playback index 2 is transcript index 1: the spoken title occupies
+    // playback index 0 and is not displayed.
+    engine.spoken()[2].onstart!();
 
     await waitFor(() =>
       expect(screen.getByText(/It landed after 362 patches\./)).toHaveAttribute(
@@ -99,18 +128,16 @@ describe("AudioSummaryPlayer", () => {
     expect(engine.resume).toHaveBeenCalledOnce();
   });
 
-  it("restarts from the first sentence", async () => {
+  it("restarts from the spoken title", async () => {
     const engine = installSpeechEngine();
 
     render(<AudioSummaryPlayer {...props} />);
-    await waitFor(() => expect(engine.spoken()).toHaveLength(3));
+    await waitFor(() => expect(engine.spoken()).toHaveLength(4));
 
     await userEvent.click(screen.getByRole("button", { name: /restart/i }));
 
-    const respoken = engine.spoken().slice(3);
-    expect(respoken[0].text).toBe(
-      "Kernel 7.2 removes strncpy. Written by Jane Doe, from Hacker News.",
-    );
+    const respoken = engine.spoken().slice(4);
+    expect(respoken[0].text).toBe(SPOKEN_TITLE);
   });
 
   it("restores a saved rate and applies it to speech", async () => {
@@ -144,8 +171,8 @@ describe("AudioSummaryPlayer", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps the spoken opening and explains itself when generation fails", async () => {
-    const engine = installSpeechEngine();
+  it("explains itself when generation fails", async () => {
+    installSpeechEngine();
     vi.mocked(readStreamableValue).mockImplementationOnce(
       () =>
         ({
@@ -158,13 +185,9 @@ describe("AudioSummaryPlayer", () => {
     render(<AudioSummaryPlayer {...props} />);
 
     expect(await screen.findByText(/briefing incomplete/i)).toBeInTheDocument();
-    // The locally-built opening needs no model, so it still plays.
-    expect(engine.spoken()[0].text).toBe(
-      "Kernel 7.2 removes strncpy. Written by Jane Doe, from Hacker News.",
-    );
   });
 
-  it("applies a stored rate only once, despite Strict Mode double-invoking effects", async () => {
+  it("speaks each sentence exactly once under Strict Mode", async () => {
     window.localStorage.setItem("briefing-officer:speech-rate", "1.5");
     const engine = installSpeechEngine();
 
@@ -175,24 +198,30 @@ describe("AudioSummaryPlayer", () => {
     );
 
     await waitFor(() => expect(screen.getByText("1.5×")).toBeInTheDocument());
-    // Re-applying the rate while playing would cancel and re-speak the queue,
-    // so the opening line would be heard twice.
-    //
+    await waitFor(() =>
+      expect(engine.spoken().length).toBeGreaterThanOrEqual(4),
+    );
+
     // Count only utterances queued after the last cancel: the fake's cancel()
     // does not discard queued utterances the way a real engine does, so
-    // spoken() also contains ones that were cancelled before making a sound —
-    // including the opening that Strict Mode's cleanup cancelled.
+    // spoken() also contains ones that were cancelled before making a sound.
     const lastCancel = Math.max(0, ...engine.cancel.mock.invocationCallOrder);
-    const liveOpenings = engine.speak.mock.calls.filter(
-      (call, index) =>
-        (call[0] as unknown as { text: string }).text.startsWith(
-          "Kernel 7.2",
-        ) && engine.speak.mock.invocationCallOrder[index] > lastCancel,
-    );
-    expect(liveOpenings).toHaveLength(1);
+    const live = engine.speak.mock.calls
+      .filter(
+        (_, index) => engine.speak.mock.invocationCallOrder[index] > lastCancel,
+      )
+      .map((call) => (call[0] as unknown as { text: string }).text);
+
+    expect(live).toEqual([
+      SPOKEN_TITLE,
+      "Published at Hacker News, written by Jane Doe.",
+      "It landed after 362 patches.",
+      "Maintainers had warned for years.",
+    ]);
+    expect(engine.spoken().at(-1)!.rate).toBe(1.5);
   });
 
-  it("still speaks the opening after Strict Mode's cleanup cancels playback", async () => {
+  it("still speaks the briefing after Strict Mode's cleanup cancels playback", async () => {
     const engine = installSpeechEngine();
 
     render(
@@ -202,25 +231,24 @@ describe("AudioSummaryPlayer", () => {
     );
 
     // The cleanup between Strict Mode's two mount passes cancels playback via
-    // the hook's unmount effect. Without a replay on remount the opening is
-    // silenced for good, because the initialized guard stops it being enqueued
-    // a second time — losing the whole point of building it locally.
+    // the hook's unmount effect. Without the remount branch's replay, playback
+    // stays dead and nothing reaches the engine afterwards.
     //
     // Asserting on ordering rather than on spoken() is deliberate: the fake's
     // cancel() does not discard queued utterances the way a real engine does,
     // so spoken() alone cannot tell a live utterance from a cancelled one.
-    // What matters is that the opening reaches the engine after the last
-    // cancel, and so survives in the live queue.
-    await waitFor(() => expect(engine.cancel).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(engine.spoken().length).toBeGreaterThanOrEqual(4),
+    );
 
     const lastCancel = Math.max(...engine.cancel.mock.invocationCallOrder);
-    const openingSpokenAfterCancel = engine.speak.mock.calls.some(
+    const spokenAfterCancel = engine.speak.mock.calls.some(
       (call, index) =>
         (call[0] as unknown as { text: string }).text.startsWith(
-          "Kernel 7.2 removes strncpy. Written by Jane Doe",
+          "Kernel 7.2 removes strncpy",
         ) && engine.speak.mock.invocationCallOrder[index] > lastCancel,
     );
-    expect(openingSpokenAfterCancel).toBe(true);
+    expect(spokenAfterCancel).toBe(true);
   });
 
   it("stops feeding the speech engine once the page unmounts", async () => {
@@ -233,13 +261,14 @@ describe("AudioSummaryPlayer", () => {
       () =>
         ({
           async *[Symbol.asyncIterator]() {
-            yield "First sentence here. ";
+            yield "First sentence here.\n";
             await gate;
-            yield "Late sentence arrives. ";
+            yield "Late sentence arrives.\n";
           },
         }) as never,
     );
 
+    // Two: the spoken title, then the stream's first sentence.
     const { unmount } = render(<AudioSummaryPlayer {...props} />);
     await waitFor(() => expect(engine.spoken()).toHaveLength(2));
 
@@ -263,5 +292,15 @@ describe("AudioSummaryPlayer", () => {
     expect(
       await screen.findByText(/It landed after 362 patches\./),
     ).toBeInTheDocument();
+  });
+
+  it("warns when no voice matches the article's language", async () => {
+    installSpeechEngine([{ name: "Test Voice", lang: "en-US" }]);
+
+    render(<AudioSummaryPlayer {...props} language="de" />);
+
+    expect(await screen.findByText(/no German voice/i)).toBeInTheDocument();
+    // The reader can still play it, knowing it will be mispronounced.
+    expect(screen.getByRole("button", { name: /pause|play/i })).toBeEnabled();
   });
 });

--- a/tests/components/hooks/use-speech-synthesis.test.tsx
+++ b/tests/components/hooks/use-speech-synthesis.test.tsx
@@ -7,7 +7,7 @@ afterEach(() => vi.unstubAllGlobals());
 
 describe("useSpeechSynthesis", () => {
   it("is unsupported when the browser has no speech engine", () => {
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     expect(result.current.supported).toBe(false);
   });
@@ -16,11 +16,11 @@ describe("useSpeechSynthesis", () => {
     const voices: unknown[] = [];
     const engine = installSpeechEngine(voices);
 
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
     expect(result.current.supported).toBe(false);
 
     // Chrome fires voiceschanged once the engine has enumerated its voices.
-    voices.push({ name: "Test Voice" });
+    voices.push({ name: "Test Voice", lang: "en-US" });
     const [event, listener] = engine.addEventListener.mock.calls[0];
     expect(event).toBe("voiceschanged");
     act(() => listener());
@@ -30,7 +30,7 @@ describe("useSpeechSynthesis", () => {
 
   it("does not speak sentences enqueued before playback starts", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => result.current.enqueue("One."));
 
@@ -39,7 +39,7 @@ describe("useSpeechSynthesis", () => {
 
   it("speaks the retained sentences in order once playback starts", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -56,7 +56,7 @@ describe("useSpeechSynthesis", () => {
 
   it("appends to the live queue without restarting playback", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -75,7 +75,7 @@ describe("useSpeechSynthesis", () => {
 
   it("tracks which sentence is speaking", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -93,7 +93,7 @@ describe("useSpeechSynthesis", () => {
 
   it("stops speaking once the final sentence ends", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -111,7 +111,7 @@ describe("useSpeechSynthesis", () => {
 
   it("ignores end events from a queue that was thrown away", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -128,7 +128,7 @@ describe("useSpeechSynthesis", () => {
 
   it("pauses and resumes without ending playback", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -150,7 +150,7 @@ describe("useSpeechSynthesis", () => {
 
   it("cancels playback and clears the active sentence", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -165,7 +165,7 @@ describe("useSpeechSynthesis", () => {
 
   it("applies the rate to newly spoken utterances", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => result.current.setRate(1.5));
     act(() => {
@@ -179,7 +179,7 @@ describe("useSpeechSynthesis", () => {
 
   it("re-speaks from the active sentence when the rate changes mid-playback", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -199,7 +199,7 @@ describe("useSpeechSynthesis", () => {
 
   it("only stores the rate when nothing is playing", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => result.current.enqueue("One."));
     act(() => result.current.setRate(1.5));
@@ -210,7 +210,7 @@ describe("useSpeechSynthesis", () => {
 
   it("cancels playback when the component unmounts", () => {
     const engine = installSpeechEngine();
-    const { result, unmount } = renderHook(() => useSpeechSynthesis());
+    const { result, unmount } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -224,7 +224,7 @@ describe("useSpeechSynthesis", () => {
 
   it("un-pauses the engine when re-speaking, since cancel does not clear it", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -241,7 +241,7 @@ describe("useSpeechSynthesis", () => {
 
   it("resumes speaking when a sentence arrives after the stream stalled", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -262,7 +262,7 @@ describe("useSpeechSynthesis", () => {
 
   it("does not resume after the listener deliberately stopped playback", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -278,7 +278,7 @@ describe("useSpeechSynthesis", () => {
 
   it("keeps its place when the rate changes twice before speech starts", () => {
     const engine = installSpeechEngine();
-    const { result } = renderHook(() => useSpeechSynthesis());
+    const { result } = renderHook(() => useSpeechSynthesis("en"));
 
     act(() => {
       result.current.enqueue("One.");
@@ -299,5 +299,103 @@ describe("useSpeechSynthesis", () => {
     // the final retained sentence either way.
     const respoken = engine.spoken().slice(spokenAfterFirstChange);
     expect(respoken.map((utterance) => utterance.text)).toEqual(["Three."]);
+  });
+
+  it("speaks with a voice matching the article's language", () => {
+    const german = { name: "Anna", lang: "de-DE" };
+    const engine = installSpeechEngine([
+      { name: "Test Voice", lang: "en-US" },
+      german,
+    ]);
+
+    const { result } = renderHook(() => useSpeechSynthesis("de"));
+    act(() => result.current.enqueue("Guten Tag."));
+    act(() => result.current.playFrom(0));
+
+    expect(result.current.voiceAvailable).toBe(true);
+    expect(engine.spoken()[0].voice).toBe(german);
+    expect(engine.spoken()[0].lang).toBe("de");
+  });
+
+  it("matches voices that report an underscore separator", () => {
+    // Chrome reports "de-DE"; some Linux engines report "de_DE".
+    const german = { name: "Anna", lang: "de_DE" };
+    const engine = installSpeechEngine([german]);
+
+    const { result } = renderHook(() => useSpeechSynthesis("de"));
+    act(() => result.current.enqueue("Guten Tag."));
+    act(() => result.current.playFrom(0));
+
+    expect(engine.spoken()[0].voice).toBe(german);
+  });
+
+  it("leaves the voice unset when none matches, but still speaks", () => {
+    const engine = installSpeechEngine([{ name: "Test Voice", lang: "en-US" }]);
+
+    const { result } = renderHook(() => useSpeechSynthesis("de"));
+    act(() => result.current.enqueue("Guten Tag."));
+    act(() => result.current.playFrom(0));
+
+    expect(result.current.supported).toBe(true);
+    expect(result.current.voiceAvailable).toBe(false);
+    // The engine gets its own fallback rather than an undefined voice, and
+    // `lang` still tells it what it is reading.
+    expect(engine.spoken()[0].voice).toBeUndefined();
+    expect(engine.spoken()[0].lang).toBe("de");
+  });
+
+  it("treats a missing language as English", () => {
+    const english = { name: "Test Voice", lang: "en-US" };
+    const engine = installSpeechEngine([english]);
+
+    const { result } = renderHook(() => useSpeechSynthesis(null));
+    act(() => result.current.enqueue("Hello."));
+    act(() => result.current.playFrom(0));
+
+    expect(result.current.voiceAvailable).toBe(true);
+    expect(engine.spoken()[0].voice).toBe(english);
+    expect(engine.spoken()[0].lang).toBe("en");
+  });
+
+  it("finds a matching voice that loads late", () => {
+    const voices: unknown[] = [];
+    const engine = installSpeechEngine(voices);
+
+    const { result } = renderHook(() => useSpeechSynthesis("de"));
+    expect(result.current.voiceAvailable).toBe(false);
+
+    voices.push({ name: "Anna", lang: "de-DE" });
+    const [, listener] = engine.addEventListener.mock.calls[0];
+    act(() => listener());
+
+    expect(result.current.voiceAvailable).toBe(true);
+  });
+
+  it("cancels playback when the owning instance unmounts", () => {
+    const engine = installSpeechEngine();
+    const only = renderHook(() => useSpeechSynthesis("en"));
+
+    engine.cancel.mockClear();
+    only.unmount();
+
+    expect(engine.cancel).toHaveBeenCalled();
+  });
+
+  it("does not cancel playback once a newer instance has taken over", () => {
+    // A router navigation commits inside a transition, so the outgoing page's
+    // cleanup can run after the incoming page has mounted and queued its
+    // opening line. Cancelling then would silence the new page.
+    const engine = installSpeechEngine();
+    const outgoing = renderHook(() => useSpeechSynthesis("en"));
+    const incoming = renderHook(() => useSpeechSynthesis("en"));
+
+    act(() => incoming.result.current.enqueue("Fresh headline."));
+    act(() => incoming.result.current.playFrom(0));
+    engine.cancel.mockClear();
+
+    outgoing.unmount();
+
+    expect(engine.cancel).not.toHaveBeenCalled();
+    expect(engine.spoken().at(-1)!.text).toBe("Fresh headline.");
   });
 });

--- a/tests/helpers/speech-synthesis.ts
+++ b/tests/helpers/speech-synthesis.ts
@@ -7,6 +7,8 @@ import { vi } from "vitest";
 export class FakeUtterance {
   text: string;
   rate = 1;
+  lang = "";
+  voice: unknown = undefined;
   onstart: (() => void) | null = null;
   onend: (() => void) | null = null;
   onerror: (() => void) | null = null;
@@ -25,7 +27,7 @@ export class FakeUtterance {
  * queue the real engine would play back to back.
  */
 export const installSpeechEngine = (
-  voices: unknown[] = [{ name: "Test Voice" }],
+  voices: unknown[] = [{ name: "Test Voice", lang: "en-US" }],
 ) => {
   const speechSynthesis = {
     speak: vi.fn(),

--- a/tests/integration/leadService.test.ts
+++ b/tests/integration/leadService.test.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prismaClient";
+import { generateObject } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createArticle, createFeed, createUser } from "../helpers/factories";
 
@@ -9,13 +10,19 @@ vi.mock("@/lib/ai/registry", () => ({
   })),
 }));
 vi.mock("ai", () => ({
-  generateText: vi.fn(async () => ({
-    text: "Generated lead.",
-    totalUsage: { inputTokens: 7, outputTokens: 3, reasoningTokens: 0 },
+  generateObject: vi.fn(async () => ({
+    object: { language: "en", lead: "Generated lead." },
+    usage: { inputTokens: 7, outputTokens: 3 },
   })),
 }));
 
 import { generateAiLead } from "@/lib/ai/services/leadService";
+
+const mockGeneration = (language: string, lead = "Generated lead.") =>
+  vi.mocked(generateObject).mockResolvedValueOnce({
+    object: { language, lead },
+    usage: { inputTokens: 7, outputTokens: 3 },
+  } as never);
 
 let userId: string;
 let feedId: number;
@@ -42,5 +49,71 @@ describe("generateAiLead", () => {
     });
     expect(usage.inputTokens).toBe(7);
     expect(usage.outputTokens).toBe(3);
+  });
+
+  it("stores the language the model reported", async () => {
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("de");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+    });
+    expect(stored.language).toBe("de");
+  });
+
+  it("normalises a regional tag before storing it", async () => {
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("de-DE");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+    });
+    expect(stored.language).toBe("de");
+  });
+
+  it("stores no language when the model reports it as undetermined", async () => {
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("und");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+    });
+    expect(stored.language).toBeNull();
+  });
+
+  it("keeps the lead when the reported language is unusable", async () => {
+    // A bad language code must not cost the reader their lead.
+    const article = await createArticle({ userId, feedId });
+    mockGeneration("German", "Trotzdem ein Lead.");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+      include: { lead: true },
+    });
+    expect(stored.language).toBeNull();
+    expect(stored.lead?.text).toBe("Trotzdem ein Lead.");
+  });
+
+  it("replaces an existing lead rather than failing", async () => {
+    const article = await createArticle({ userId, feedId });
+    await generateAiLead(article.id);
+    mockGeneration("fr", "Un nouveau lead.");
+
+    await generateAiLead(article.id);
+
+    const stored = await prisma.article.findUniqueOrThrow({
+      where: { id: article.id },
+      include: { lead: true },
+    });
+    expect(stored.lead?.text).toBe("Un nouveau lead.");
+    expect(stored.language).toBe("fr");
   });
 });

--- a/tests/unit/audio-script.test.ts
+++ b/tests/unit/audio-script.test.ts
@@ -1,162 +1,100 @@
-import { buildOpeningLine, splitIntoSentences } from "@/lib/audio-script";
+import { splitIntoSentences, spokenTitle } from "@/lib/audio-script";
 import { describe, expect, it } from "vitest";
 
-describe("buildOpeningLine", () => {
-  it("names the article, its author, and its feed", () => {
-    expect(
-      buildOpeningLine("Kernel 7.2 removes strncpy", "Jane Doe", "Hacker News"),
-    ).toBe(
-      "Kernel 7.2 removes strncpy. Written by Jane Doe, from Hacker News.",
+describe("spokenTitle", () => {
+  it("terminates a headline so it does not run into the next sentence", () => {
+    expect(spokenTitle("Kernel 7.2 removes strncpy")).toBe(
+      "Kernel 7.2 removes strncpy.",
     );
   });
 
-  it("drops the attribution when the scraper found no byline", () => {
-    // scraper.ts stores "" when Readability finds no byline, which is common.
-    expect(
-      buildOpeningLine("Kernel 7.2 removes strncpy", "", "Hacker News"),
-    ).toBe("Kernel 7.2 removes strncpy. From Hacker News.");
+  it("keeps a headline's own terminal punctuation", () => {
+    // Headlines frequently end in "?" or "!", and replacing those with a
+    // period changes how the voice reads the line.
+    expect(spokenTitle("Is Rust dead?")).toBe("Is Rust dead?");
+    expect(spokenTitle("It shipped!")).toBe("It shipped!");
+    expect(spokenTitle("It shipped.")).toBe("It shipped.");
   });
 
-  it("drops the attribution when the author is null or undefined", () => {
-    expect(buildOpeningLine("A title", null, "Hacker News")).toBe(
-      "A title. From Hacker News.",
-    );
-    expect(buildOpeningLine("A title", undefined, "Hacker News")).toBe(
-      "A title. From Hacker News.",
-    );
-  });
-
-  it("keeps a title's own terminal punctuation instead of adding a period", () => {
-    // Headlines ending in "?" or "!" are common; running them into a comma
-    // would read as an audible glitch.
-    expect(buildOpeningLine("Is Rust dead?", "Jane Doe", "Hacker News")).toBe(
-      "Is Rust dead? Written by Jane Doe, from Hacker News.",
-    );
-    expect(buildOpeningLine("Ship it!", "", "Hacker News")).toBe(
-      "Ship it! From Hacker News.",
-    );
-  });
-
-  it("speaks the author verbatim without tidying the byline", () => {
-    // Normalising bylines here would create a second place that knows how to
-    // clean them up, making the real fix harder. See the spec's non-goals.
-    expect(buildOpeningLine("A title", "By Jane Doe", "Hacker News")).toBe(
-      "A title. Written by By Jane Doe, from Hacker News.",
+  it("trims surrounding whitespace", () => {
+    expect(spokenTitle("  Kernel 7.2 removes strncpy  ")).toBe(
+      "Kernel 7.2 removes strncpy.",
     );
   });
 });
 
 describe("splitIntoSentences", () => {
-  it("returns complete sentences and keeps the unterminated tail", () => {
+  it("returns complete lines and keeps the unterminated tail", () => {
     expect(
-      splitIntoSentences("Linux 7.2 drops strncpy. It landed Fri"),
+      splitIntoSentences("Linux 7.2 drops strncpy.\nIt landed Fri"),
     ).toEqual({
       sentences: ["Linux 7.2 drops strncpy."],
       remainder: "It landed Fri",
     });
   });
 
-  it("splits on question and exclamation marks", () => {
-    expect(splitIntoSentences("Is Rust dead? No! Not yet")).toEqual({
-      sentences: ["Is Rust dead?", "No!"],
-      remainder: "Not yet",
+  it("finds several sentences in one buffer", () => {
+    expect(splitIntoSentences("One.\nTwo.\nThree")).toEqual({
+      sentences: ["One.", "Two."],
+      remainder: "Three",
     });
   });
 
-  it("does not split inside a decimal number", () => {
-    expect(
-      splitIntoSentences("Revenue rose 3.5 percent last year. And more"),
-    ).toEqual({
-      sentences: ["Revenue rose 3.5 percent last year."],
-      remainder: "And more",
-    });
-  });
-
-  it("does not split after a common abbreviation", () => {
-    expect(splitIntoSentences("Dr. Smith arrived. Then left")).toEqual({
-      sentences: ["Dr. Smith arrived."],
-      remainder: "Then left",
-    });
-  });
-
-  it("does not split inside an acronym with periods", () => {
-    expect(splitIntoSentences("The U.S. government agreed. Later on")).toEqual({
-      sentences: ["The U.S. government agreed."],
-      remainder: "Later on",
-    });
-  });
-
-  it("treats an ellipsis as a pause, not a sentence end", () => {
-    expect(splitIntoSentences("Well... anyway. Next up")).toEqual({
-      sentences: ["Well... anyway."],
-      remainder: "Next up",
-    });
-  });
-
-  it("holds back a terminator that no whitespace has confirmed yet", () => {
-    // Mid-stream, "3." may still become "3.5", so a terminator only counts
-    // once the following character has arrived.
+  it("holds everything back until a newline arrives", () => {
     expect(splitIntoSentences("It cost 3.")).toEqual({
       sentences: [],
       remainder: "It cost 3.",
     });
   });
 
-  it("returns nothing for empty and whitespace-only input", () => {
-    expect(splitIntoSentences("")).toEqual({ sentences: [], remainder: "" });
-    expect(splitIntoSentences("   ")).toEqual({ sentences: [], remainder: "" });
+  it("does not split on punctuation inside a line", () => {
+    // The whole point of delimiting on newlines: no abbreviation list, so
+    // "z.B." and "Dr." are equally safe in any language.
+    expect(
+      splitIntoSentences("Laut Dr. Schmidt, z.B. in Berlin, gilt das.\nDann"),
+    ).toEqual({
+      sentences: ["Laut Dr. Schmidt, z.B. in Berlin, gilt das."],
+      remainder: "Dann",
+    });
   });
 
-  it("finds several sentences in one buffer", () => {
-    expect(splitIntoSentences("One. Two. Three")).toEqual({
+  it("keeps a sentence whole across an abbreviation no English list knew", () => {
+    // The discriminating case for the rewrite: the old punctuation splitter
+    // fragmented this at "usw." because that abbreviation was absent from its
+    // English list. Newline delimiting has no such list to be absent from.
+    expect(splitIntoSentences("Vorher usw. Nachher.\nDanach")).toEqual({
+      sentences: ["Vorher usw. Nachher."],
+      remainder: "Danach",
+    });
+  });
+
+  it("ignores blank lines", () => {
+    expect(splitIntoSentences("One.\n\nTwo.\nThree")).toEqual({
       sentences: ["One.", "Two."],
       remainder: "Three",
     });
   });
 
-  it("splits after a standalone No", () => {
-    expect(splitIntoSentences("Is it done? No. Not yet")).toEqual({
-      sentences: ["Is it done?", "No."],
-      remainder: "Not yet",
+  it("trims surrounding whitespace from each sentence", () => {
+    expect(splitIntoSentences("  One.  \n Two. \nThree")).toEqual({
+      sentences: ["One.", "Two."],
+      remainder: "Three",
     });
   });
 
-  it("splits after an ordinal, which only looks like an abbreviation", () => {
-    // The letter-run regex yields "st" from "1st", which would otherwise be
-    // suppressed as the abbreviation for Saint or Street.
-    expect(splitIntoSentences("He came in 1st. Then left")).toEqual({
-      sentences: ["He came in 1st."],
-      remainder: "Then left",
-    });
+  it("returns nothing for empty input", () => {
+    expect(splitIntoSentences("")).toEqual({ sentences: [], remainder: "" });
   });
 
-  it("still does not split after Saint or Street", () => {
-    expect(splitIntoSentences("St. Louis grew. Then more")).toEqual({
-      sentences: ["St. Louis grew."],
-      remainder: "Then more",
-    });
-  });
+  it("survives being fed its own remainder with the next delta appended", () => {
+    // How the player actually drives it, one streamed chunk at a time.
+    const first = splitIntoSentences("One.\nTwo");
+    expect(first.sentences).toEqual(["One."]);
 
-  it("splits after a multi-digit ordinal", () => {
-    // Guards the digit-lookback arithmetic, which single-digit ordinals alone
-    // would not catch if it were ever changed.
-    expect(splitIntoSentences("She placed 21st. Then rested")).toEqual({
-      sentences: ["She placed 21st."],
-      remainder: "Then rested",
+    const second = splitIntoSentences(`${first.remainder} and a half.\nThree`);
+    expect(second).toEqual({
+      sentences: ["Two and a half."],
+      remainder: "Three",
     });
-  });
-
-  it("keeps a trailing space that separates two words across deltas", () => {
-    // The player feeds the remainder back with the next delta appended, so a
-    // trailing space dropped here glues two words into one.
-    let buffer = "";
-    const spoken: string[] = [];
-    for (const delta of ["It landed after ", "362 patches. "]) {
-      buffer += delta;
-      const { sentences, remainder } = splitIntoSentences(buffer);
-      buffer = remainder;
-      spoken.push(...sentences);
-    }
-    expect(spoken).toEqual(["It landed after 362 patches."]);
   });
 });

--- a/tests/unit/audioSummaryPageLayout.test.ts
+++ b/tests/unit/audioSummaryPageLayout.test.ts
@@ -17,11 +17,15 @@ describe("Audio summary page layout", () => {
     expect(pageSource).toContain("<BackButton />");
   });
 
-  it("passes the article's own metadata to the player", () => {
-    // The opening line is built from these, so they must reach the client.
+  it("passes the article's language and title to the player", () => {
+    // Language picks the voice; the title is spoken from code so playback can
+    // start before the model returns anything. The author and publication do
+    // not travel to the client — the server action loads those itself for the
+    // generated part of the introduction.
     expect(pageSource).toContain("<AudioSummaryPlayer");
-    expect(pageSource).toContain("feedTitle={article.feed.title}");
-    expect(pageSource).toContain("author={articleAuthor(article)}");
+    expect(pageSource).toContain("language={article.language}");
+    expect(pageSource).toContain("title={article.title}");
+    expect(pageSource).not.toContain("feedTitle={article.feed.title}");
   });
 
   it("explains itself when the article body could not be retrieved", () => {

--- a/tests/unit/language.test.ts
+++ b/tests/unit/language.test.ts
@@ -1,0 +1,59 @@
+import { languageDisplayName, normalizeLanguage } from "@/lib/language";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeLanguage", () => {
+  it("accepts a two-letter ISO 639-1 code", () => {
+    expect(normalizeLanguage("de")).toBe("de");
+    expect(normalizeLanguage("en")).toBe("en");
+  });
+
+  it("reduces a regional tag to its primary subtag", () => {
+    // Engines and models disagree on the separator.
+    expect(normalizeLanguage("de-DE")).toBe("de");
+    expect(normalizeLanguage("de_DE")).toBe("de");
+    expect(normalizeLanguage("pt-BR")).toBe("pt");
+  });
+
+  it("lowercases and trims", () => {
+    expect(normalizeLanguage("DE")).toBe("de");
+    expect(normalizeLanguage("  de  ")).toBe("de");
+  });
+
+  it("rejects the undetermined sentinel", () => {
+    // Load-bearing: Intl.DisplayNames.of("und") returns "root", so the
+    // recognition check does NOT catch it. Only the two-letter rule does.
+    expect(normalizeLanguage("und")).toBeNull();
+  });
+
+  it("rejects ISO 639-2 codes", () => {
+    // Load-bearing for the same reason: .of("deu") returns "German".
+    expect(normalizeLanguage("deu")).toBeNull();
+    expect(normalizeLanguage("ger")).toBeNull();
+  });
+
+  it("rejects language names and unrecognised codes", () => {
+    expect(normalizeLanguage("German")).toBeNull();
+    expect(normalizeLanguage("xx")).toBeNull();
+    expect(normalizeLanguage("un")).toBeNull();
+  });
+
+  it("rejects empty and missing values without throwing", () => {
+    // Intl.DisplayNames.of("") throws a RangeError, so the shape check has to
+    // run first.
+    expect(normalizeLanguage("")).toBeNull();
+    expect(normalizeLanguage("   ")).toBeNull();
+    expect(normalizeLanguage(null)).toBeNull();
+    expect(normalizeLanguage(undefined)).toBeNull();
+  });
+});
+
+describe("languageDisplayName", () => {
+  it("names a language in English", () => {
+    expect(languageDisplayName("de")).toBe("German");
+    expect(languageDisplayName("fr")).toBe("French");
+  });
+
+  it("falls back to English when no language was established", () => {
+    expect(languageDisplayName(null)).toBe("English");
+  });
+});

--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -12,39 +12,130 @@ describe("buildLeadPrompt", () => {
     expect(prompt).toContain("Body text here");
     expect(prompt).toContain("no longer than 80 words");
   });
+
+  it("asks the model to report the language as an ISO 639-1 code", () => {
+    // The lead is the one call that determines the language; everything
+    // downstream reads what it stored.
+    const prompt = buildLeadPrompt("My Title", "Body text here");
+    expect(prompt).toContain("ISO 639-1");
+    expect(prompt).toContain('"und"');
+  });
+
+  it("asks for the lead in the language it reports", () => {
+    const prompt = buildLeadPrompt("My Title", "Body text here");
+    expect(prompt).toContain("in the language you reported");
+  });
 });
 
 describe("buildSummaryPrompt", () => {
   it("includes the article text and Markdown structure cues", () => {
-    const prompt = buildSummaryPrompt("My Title", "Body text here");
+    const prompt = buildSummaryPrompt("My Title", "Body text here", null);
     expect(prompt).toContain("My Title");
     expect(prompt).toContain("Body text here");
     expect(prompt).toContain("Key Facts");
     expect(prompt).toContain("Key Takeaways");
   });
+
+  it("names the article's language", () => {
+    const prompt = buildSummaryPrompt("My Title", "Body text here", "de");
+    expect(prompt).toContain("Write entirely in German.");
+  });
+
+  it("falls back to English when no language was established", () => {
+    const prompt = buildSummaryPrompt("My Title", "Body text here", null);
+    expect(prompt).toContain("Write entirely in English.");
+  });
+
+  it("asks for the heading to be translated too", () => {
+    // The heading names are given in English as selection criteria, so
+    // without this a German summary gets German bullets under an English
+    // heading.
+    const prompt = buildSummaryPrompt("My Title", "Body text here", "de");
+    expect(prompt).toContain("translate the one you choose");
+  });
 });
 
 describe("buildAudioScriptPrompt", () => {
-  it("includes the title and the article text", () => {
-    const prompt = buildAudioScriptPrompt("My Title", "Body text here");
+  const args = {
+    title: "My Title",
+    author: "Jane Doe",
+    feedTitle: "Hacker News",
+    textContent: "Body text here",
+    language: null as string | null,
+  };
+
+  it("includes the title, the article text, and the publication", () => {
+    const prompt = buildAudioScriptPrompt(args);
     expect(prompt).toContain("My Title");
     expect(prompt).toContain("Body text here");
+    expect(prompt).toContain("Hacker News");
   });
 
   it("asks for spoken prose of about one minute", () => {
-    const prompt = buildAudioScriptPrompt("My Title", "Body text here");
-    expect(prompt).toContain("150 to 200 words");
+    expect(buildAudioScriptPrompt(args)).toContain("150 to 200 words");
   });
 
   it("forbids Markdown, since the output is spoken rather than rendered", () => {
-    const prompt = buildAudioScriptPrompt("My Title", "Body text here");
+    const prompt = buildAudioScriptPrompt(args);
     expect(prompt).toContain("Markdown");
     expect(prompt).toContain("plain text only");
   });
 
-  it("tells the model the article has already been introduced", () => {
-    // The opening line is constructed in code, so the body must not repeat it.
-    const prompt = buildAudioScriptPrompt("My Title", "Body text here");
-    expect(prompt).toContain("already been introduced");
+  it("tells the model the title is already spoken and must not be repeated", () => {
+    // The title is spoken from code so playback can start before the model
+    // returns anything. Models restate it anyway unless told plainly, so the
+    // prohibition leads the prompt rather than sitting mid-paragraph, and the
+    // title element is labelled as context rather than material.
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("already been spoken aloud");
+    expect(prompt).toContain("Never repeat, paraphrase, translate, or refer");
+    expect(prompt).toContain("treat it as already said");
+  });
+
+  it("dictates what the first sentence must be", () => {
+    // Stating the required opening works better than only forbidding the
+    // unwanted one.
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("Your first sentence must");
+    expect(prompt).toContain("naming the publication and the author");
+  });
+
+  it("forbids openings that merely announce the article as an article", () => {
+    // "The article titled…" / "Der Artikel…" tells a listener who just heard
+    // the headline nothing at all.
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("The article titled");
+    expect(prompt).toContain("carry no information");
+  });
+
+  it("supplies the author when one is known", () => {
+    const prompt = buildAudioScriptPrompt(args);
+    expect(prompt).toContain("<author>Jane Doe</author>");
+    expect(prompt).toContain("naming the publication and the author");
+  });
+
+  it("omits the author entirely when none is known", () => {
+    // Structural guard: with no author element in the prompt there is nothing
+    // for the model to invent one from.
+    const prompt = buildAudioScriptPrompt({ ...args, author: null });
+    expect(prompt).not.toContain("<author>");
+    expect(prompt).toContain("do not mention one");
+  });
+
+  it("asks for one sentence per line", () => {
+    // Playback splits the stream on newlines, so this instruction is what
+    // makes sentence boundaries work in every language.
+    expect(buildAudioScriptPrompt(args)).toContain("own line");
+  });
+
+  it("names the article's language", () => {
+    const prompt = buildAudioScriptPrompt({ ...args, language: "de" });
+    expect(prompt).toContain("Write entirely in German.");
+  });
+
+  it("falls back to English when no language was established", () => {
+    expect(buildAudioScriptPrompt(args)).toContain(
+      "Write entirely in English.",
+    );
   });
 });


### PR DESCRIPTION
Articles in languages other than English produced unpredictable output: nothing in the pipeline stated what language to generate in, so the same feed could return German one day and English the next. Read Aloud compounded it by speaking every briefing with the browser's default — usually English — voice.

## What changes for the reader

- A German article now gets a German lead, a German text summary, and a German audio briefing.
- The briefing is spoken by a German voice where one is installed. Where none is, the page says so by name and still lets the briefing be played.
- The briefing opens with the headline read from the article itself, so audio starts as the page opens rather than after the model's first token.
- English articles are unaffected apart from the introduction, which is now assembled differently for every language.

## How it works

The language is established **once**, by the model, as a structured-output field alongside the lead already generated for every article at ingest — so it costs no extra request. The value is validated down to a lowercase two-letter ISO 639-1 code and stored on `Article.language` in the same nested write as the lead, so the two cannot drift apart. Anything the model cannot establish (`"und"`, a language name, an ISO 639-2 code) resolves to English.

All three prompts then state the target language explicitly rather than leaving it to be inferred — including when it is English, since the point is that the language is deliberate rather than guessed.

Two smaller mechanisms worth calling out for review:

- **Sentence splitting is now newline-delimited.** The old splitter inferred boundaries from punctuation using an English abbreviation list, which mis-split German (`usw.`, `bzw.`) and would mis-split every other language in its own way. The model is asked to put one sentence per line instead, so the splitter needs no language-specific knowledge at all. A test pins the discriminating case.
- **The audio introduction is split.** The headline is read verbatim from the article — it is already known exactly, so involving the model could only risk paraphrase — while the publication and author are generated, because those connectives are the part that actually needs translating.

## Deliberate omissions

- **No fallback if the model emits no newlines.** The briefing would arrive as one utterance; Chrome truncates those at ~15s, Firefox does not. Considered and rejected as overcomplication.
- **No backfill.** Articles already stored have no language and fall back to English until they age out inside the 30-day retention window.
- **No reader-facing language override.** Detection plus the English fallback is the whole story until misdetection proves to be a real problem.

## Verification

`npm run test` (171 passing), `npm run lint`, `npm run build`, and `npm run format:check` all pass. Behaviour was also checked by hand in a production build: briefing plays in the article's language, headline read once, Replay correct, and navigation between audio summaries behaves.

Design and plan are included in `docs/superpowers/`.

## Known, not addressed here

- A pre-existing hydration warning on the audio summary page (`disabled={!supported}` on the transport buttons) exists unchanged on `main` and is not introduced by this branch.
- `generateAiLead` is not scoped by `userId` the way its sibling services are. Pre-existing; this branch widens what a cross-tenant call touches from the lead row to a column on the article. It cannot be fixed trivially because the ingest path has no session.
- `tests/integration/feedRepository.test.ts` fails `npx tsc --noEmit` for an unrelated pre-existing reason (a factory missing the `author` field from d6d61c7). It does not gate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
