### PR TITLE
feat: move audio playback controls above the briefing transcript

### DIFF
--- a/src/components/article/audio-summary-player.tsx
+++ b/src/components/article/audio-summary-player.tsx
@@ -202,24 +202,7 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
         </Alert>
       )}
 
-      {/* One block per sentence, so the line structure the model emits
-          survives to the page instead of being reflowed into a paragraph. */}
-      <div className="leading-loose text-pretty">
-        {sentences.map((sentence, index) => (
-          <p
-            key={index}
-            // The hook also retains the spoken title at playback index 0,
-            // which the transcript omits, so display index i is playback
-            // index i + 1.
-            data-active={index + 1 === activeIndex}
-            className="data-[active=true]:bg-primary/15 rounded transition-colors"
-          >
-            {sentence}
-          </p>
-        ))}
-      </div>
-
-      <div className="flex flex-wrap items-center gap-4 border-t pt-4">
+      <div className="flex flex-wrap items-center gap-4 border-b pb-4">
         <Button
           variant="secondary"
           size="icon"
@@ -268,6 +251,23 @@ const AudioSummaryPlayer = (props: AudioSummaryPlayerProps) => {
             {displayedRate.toFixed(1)}×
           </span>
         </div>
+      </div>
+
+      {/* One block per sentence, so the line structure the model emits
+          survives to the page instead of being reflowed into a paragraph. */}
+      <div className="leading-loose text-pretty">
+        {sentences.map((sentence, index) => (
+          <p
+            key={index}
+            // The hook also retains the spoken title at playback index 0,
+            // which the transcript omits, so display index i is playback
+            // index i + 1.
+            data-active={index + 1 === activeIndex}
+            className="data-[active=true]:bg-primary/15 rounded transition-colors"
+          >
+            {sentence}
+          </p>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The play, restart and speed controls on the audio summary page sat below the transcript. Since the transcript grows as sentences stream in, the controls kept getting pushed down the page while the briefing was still generating.

They now render directly under the article title, so they stay within reach from the moment the page opens.

## Changes

- Moved the controls block in `audio-summary-player.tsx` above the transcript.
- Flipped its divider from `border-t pt-4` to `border-b pb-4` so the separator still falls between the controls and the text.

## Testing

`npx tsc --noEmit` reports no errors in `src/`. (Pre-existing, unrelated failures remain in `tests/integration/feedRepository.test.ts` about a missing `author` property.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)