### PR TITLE
ci: type-check the whole tree, tests included

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,6 +36,23 @@ jobs:
       - name: Run Lint
         run: npm run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Generate Prisma Client
+        run: npx prisma generate
+      - name: Run Type Check
+        run: npm run typecheck
+
   test:
     runs-on: ubuntu-latest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,10 @@ reflowed too. Ignored paths are in `.prettierignore`.
 Run these before pushing; CI gates on all of them:
 
 ```bash
-npm run lint    # ESLint
-npm run test    # Vitest unit + integration tests
-npm run build   # Next.js production build
+npm run lint       # ESLint
+npm run typecheck  # tsc --noEmit, covers tests too (the build does not)
+npm run test       # Vitest unit + integration tests
+npm run build      # Next.js production build
 ```
 
 ## Git
@@ -84,7 +85,7 @@ Standard flow:
    should already follow Conventional Commits, since the default merge method is
    **rebase** — individual commits land on `main` as-is, preserving the branch
    history.
-5. Wait for CI (`format-check`, `lint`, `test`, `build`) to pass.
+5. Wait for CI (`format-check`, `lint`, `typecheck`, `test`, `build`) to pass.
 6. The user reviews the PR before it can be merged. The user will either merge
    the PR themselves or explicitly instruct the agent to merge it. Do **not**
    merge a PR without that explicit instruction, even after CI passes. When

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prisma:migrate-dev": "prisma migrate dev",
     "prisma:studio": "prisma studio",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",

--- a/tests/integration/feedRepository.test.ts
+++ b/tests/integration/feedRepository.test.ts
@@ -39,6 +39,7 @@ const feedItem = (title: string, link: string) => ({
   description: null,
   publicationDate: new Date(),
   commentsLink: null,
+  author: null,
 });
 
 beforeEach(async () => {


### PR DESCRIPTION
Closes #739

`npx tsc --noEmit` reported **8 errors on `main`** while every CI check stayed green.

## Why nothing caught them

- `npm run test` — Vitest strips types with esbuild; never checks them.
- `npm run build` — runs TypeScript, but only over the module graph reachable from the app. Nothing in `src/` imports test files, so `tests/` is never reached.
- `npm run lint` — ESLint only, no type-aware rules.

`tsconfig.json` already includes `**/*.ts`, so `tsc` does cover tests. Nothing in CI invoked it.

## Changes

1. **Fix the existing drift** — the `feedItem` helper in `tests/integration/feedRepository.test.ts` was missing `author`, which `scrapeFeed`'s return type gained when the column was added. One field fixes all 8 errors.
2. **Add a `typecheck` script** (`tsc --noEmit`) and a CI job that runs it, so this class of drift fails the build instead of accumulating silently. The job runs `prisma generate` first, since the checked types come from the generated client.
3. **Document it** in `AGENTS.md` alongside the other pre-push checks.

## Verification

Run locally in a clean worktree:

- `npm run typecheck` — 8 errors before the fix, clean after
- `npm run test` — 23 files, 168 tests passing
- `npm run lint` — clean
- `npm run format:check` — clean

`npm run build` was not run locally; no `src/` files are touched, and the CI `build` job covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)