### PR TITLE
refactor: rename the ai-summary components to match the text-summary route

### DIFF
--- a/src/app/feed/[feedId]/article/[articleId]/text-summary/page.tsx
+++ b/src/app/feed/[feedId]/article/[articleId]/text-summary/page.tsx
@@ -1,6 +1,6 @@
-import AiSummaryStream from "@/components/article/ai-summary-stream";
 import ArticleMeta from "@/components/article/article-meta";
 import SummaryArticleActions from "@/components/article/summary-article-actions";
+import TextSummaryStream from "@/components/article/text-summary-stream";
 import IntlRelativeTime from "@/components/intl-relative-time";
 import BackButton from "@/components/navigation/back-button";
 import TopNavigation from "@/components/navigation/top-navigation";
@@ -14,7 +14,7 @@ import { notFound } from "next/navigation";
 
 export const maxDuration = 30;
 
-const AiSummary = async ({
+const TextSummary = async ({
   params,
 }: {
   params: Promise<{ feedId: string; articleId: string }>;
@@ -47,7 +47,7 @@ const AiSummary = async ({
           { name: "Feeds", href: "/feed" },
           { name: article.feed.title, href: `/feed/${article.feed.id}` },
         ]}
-        page="AI Summary"
+        page="Text Summary"
       />
 
       <article className="mx-auto flex max-w-4xl flex-col gap-4">
@@ -67,13 +67,13 @@ const AiSummary = async ({
         <ArticleMeta author={articleAuthor(article)} />
         {article.scrape ? (
           <div className="leading-relaxed">
-            <AiSummaryStream articleId={article.id} />
+            <TextSummaryStream articleId={article.id} />
           </div>
         ) : (
           <Alert className="mx-auto my-12 max-w-md">
             <AlertTitle>Summary unavailable</AlertTitle>
             <AlertDescription>
-              The article content could not be retrieved, so an AI summary
+              The article content could not be retrieved, so a text summary
               cannot be generated.
             </AlertDescription>
           </Alert>
@@ -89,4 +89,4 @@ const AiSummary = async ({
   );
 };
 
-export default AiSummary;
+export default TextSummary;

--- a/src/components/article/article-card-actions.tsx
+++ b/src/components/article/article-card-actions.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import AiSummaryButton from "@/components/article/ai-summary-button";
 import AudioSummaryButton from "@/components/article/audio-summary-button";
 import CommentsButton from "@/components/article/comments-button";
 import DismissButton from "@/components/article/dismiss-button";
+import TextSummaryButton from "@/components/article/text-summary-button";
 import ToggleReadLaterButton from "@/components/article/toggle-read-later-button";
 import ToggleStarredButton from "@/components/article/toggle-starred-button";
 import VisitButton from "@/components/article/visit-button";
@@ -72,7 +72,7 @@ const LabelledActions = ({
       onAfterDismiss={onAfterDismiss}
     />
     {currentPage !== "text-summary" && (
-      <AiSummaryButton
+      <TextSummaryButton
         feedId={article.feedId}
         articleId={article.id}
         className={className}

--- a/src/components/article/text-summary-button.tsx
+++ b/src/components/article/text-summary-button.tsx
@@ -2,22 +2,23 @@ import { Button } from "@/components/ui/button";
 import { Sparkles } from "lucide-react";
 import Link from "next/link";
 
-interface AiSummaryButtonProps {
+interface TextSummaryButtonProps {
   feedId: number;
   articleId: number;
   className?: string;
 }
 
-const AiSummaryButton = ({
+const TextSummaryButton = ({
   feedId,
   articleId,
   className,
-}: AiSummaryButtonProps) => {
+}: TextSummaryButtonProps) => {
   return (
     <Button
       asChild
       variant="secondary"
       className={className ?? "justify-start text-sm"}
+      aria-label="Text summary"
     >
       <Link href={`/feed/${feedId}/article/${articleId}/text-summary`}>
         <Sparkles className="mr-1 size-4" />
@@ -27,4 +28,4 @@ const AiSummaryButton = ({
   );
 };
 
-export default AiSummaryButton;
+export default TextSummaryButton;

--- a/src/components/article/text-summary-stream.tsx
+++ b/src/components/article/text-summary-stream.tsx
@@ -1,18 +1,18 @@
 "use client";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { streamAiSummary } from "@/lib/ai/services/summaryService";
+import { streamTextSummary } from "@/lib/ai/services/summaryService";
 import { readStreamableValue } from "@ai-sdk/rsc";
 import Markdown from "markdown-to-jsx";
 import { useEffect, useRef, useState } from "react";
 
 export const maxDuration = 30;
 
-interface AiSummaryStreamProps {
+interface TextSummaryStreamProps {
   articleId: number;
 }
 
-const AiSummaryStream = ({ articleId }: AiSummaryStreamProps) => {
+const TextSummaryStream = ({ articleId }: TextSummaryStreamProps) => {
   const initialized = useRef(false);
   const [generation, setGeneration] = useState<string>("");
   const [failed, setFailed] = useState(false);
@@ -25,7 +25,7 @@ const AiSummaryStream = ({ articleId }: AiSummaryStreamProps) => {
       setGeneration(""); // Reset state
 
       try {
-        const { output } = await streamAiSummary(articleId);
+        const { output } = await streamTextSummary(articleId);
 
         for await (const delta of readStreamableValue(output)) {
           setGeneration((currentGeneration) => `${currentGeneration}${delta}`);
@@ -94,4 +94,4 @@ const AiSummaryStream = ({ articleId }: AiSummaryStreamProps) => {
   );
 };
 
-export default AiSummaryStream;
+export default TextSummaryStream;

--- a/src/lib/ai/services/summaryService.ts
+++ b/src/lib/ai/services/summaryService.ts
@@ -5,7 +5,7 @@ import { streamGeneration } from "@/lib/ai/streamGeneration";
 import prisma from "@/lib/prismaClient";
 import { getUserId } from "@/lib/repository/userRepository";
 
-export const streamAiSummary = async (articleId: number) => {
+export const streamTextSummary = async (articleId: number) => {
   const userId = await getUserId();
 
   const article = await prisma.article.findUniqueOrThrow({
@@ -15,7 +15,7 @@ export const streamAiSummary = async (articleId: number) => {
 
   return streamGeneration({
     userId,
-    label: "AI summary",
+    label: "Text summary",
     context: {
       articleId,
       feedId: article.feedId,

--- a/tests/components/article/article-card-actions.test.tsx
+++ b/tests/components/article/article-card-actions.test.tsx
@@ -37,11 +37,11 @@ describe("ArticleCardActions", () => {
     expect(links[0]).toHaveAttribute("href", "/feed/1/article/1/audio-summary");
   });
 
-  it("hides the summarize entry on the text summary page", () => {
+  it("hides the text summary entry on the text summary page", () => {
     render(<ArticleCardActions article={article} currentPage="text-summary" />);
 
     expect(
-      screen.queryByRole("link", { name: /summarize/i }),
+      screen.queryByRole("link", { name: /text summary/i }),
     ).not.toBeInTheDocument();
     expect(
       screen.getAllByRole("link", { name: /audio summary/i }),
@@ -56,6 +56,8 @@ describe("ArticleCardActions", () => {
     expect(
       screen.queryByRole("link", { name: /audio summary/i }),
     ).not.toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: /summarize/i })).toHaveLength(2);
+    expect(screen.getAllByRole("link", { name: /text summary/i })).toHaveLength(
+      2,
+    );
   });
 });


### PR DESCRIPTION
Closes #738.

`50def53` renamed the route `ai-summary` → `text-summary` but left the component layer on the old name, so the codebase used two names for one feature — most visibly a breadcrumb reading "AI Summary" over a `/text-summary` URL.

## Changes

| Was | Now |
|---|---|
| `ai-summary-button.tsx`, `AiSummaryButton(Props)` | `text-summary-button.tsx`, `TextSummaryButton(Props)` |
| `ai-summary-stream.tsx`, `AiSummaryStream(Props)` | `text-summary-stream.tsx`, `TextSummaryStream(Props)` |
| `const AiSummary` (page) | `const TextSummary` |
| `streamAiSummary` | `streamTextSummary` |
| log label `"AI summary"` | `"Text summary"` |
| breadcrumb `page="AI Summary"` | `page="Text Summary"` |
| alert: "so an AI summary cannot be generated" | "so a text summary cannot be generated" |

Dropping the "AI" qualifier follows the reasoning in the issue: it no longer distinguishes anything now that the audio briefing is equally AI-generated. The real axis is text vs. audio, which the route names already say.

## The button label

Settled deliberately, as the issue asked: the visible wording stays **`Summarize`**, and the button gains `aria-label="Text summary"` so it names its destination the way the icon-only audio button does.

Worth knowing: an `aria-label` replaces the visible text as the accessible name, so the button's accessible name is now "Text summary" while it reads "Summarize" on screen. That divergence is what WCAG 2.5.3 (Label in Name) cautions about for voice-control users, who may say "Summarize" and not match it. Easy to change later — a `title` attribute would add the hint without touching the accessible name. The component tests now query by the new accessible name.

## Verification

All four CI gates run locally on this branch: `format:check`, `lint`, `test` (168 passing), `build`.

Behaviour is otherwise unchanged and no route paths moved. Hits in `docs/superpowers/**` are historical planning records and were left as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
