### PR TITLE
chore: approve install scripts for the four packages that need them

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,5 +128,11 @@
     "@types/react-dom": "19.2.3",
     "jsdom": "^24.1.3",
     "kysely": "^0.28.17"
+  },
+  "allowScripts": {
+    "@prisma/engines@7.9.1": true,
+    "better-sqlite3@12.11.1": true,
+    "esbuild@0.28.1": true,
+    "prisma@7.9.1": true
   }
 }


### PR DESCRIPTION
Silences the `npm warn allow-scripts` block that appears on every `npm ci`.

npm gates package install scripts behind an `allowScripts` allowlist. The repo had no `.npmrc` and no `allowScripts` key, so all four packages with install scripts were flagged as unreviewed on every install.

## The four packages

All have a legitimate need for install-time scripts:

| Package | Script | Why it needs one |
|---|---|---|
| `better-sqlite3@12.11.1` | `prebuild-install \|\| node-gyp rebuild` | Fetches or compiles the native SQLite binding |
| `esbuild@0.28.1` | `node install.js` | Installs the platform-specific binary |
| `@prisma/engines@7.9.1` | `node scripts/postinstall.js` | Fetches query/schema engines |
| `prisma@7.9.1` | `node scripts/preinstall-entry.js` | CLI preinstall check |

## Pinning

Entries are written as `pkg@version` via `--allow-scripts-pin` rather than bare package names:

```json
"allowScripts": {
  "@prisma/engines@7.9.1": true,
  "better-sqlite3@12.11.1": true,
  "esbuild@0.28.1": true,
  "prisma@7.9.1": true
}
```

Approving grants these packages arbitrary code execution at install time, so pinning matters: a future version cannot inherit the approval silently — a bump re-triggers the warning and forces an explicit re-review. The tradeoff is that version bumps to these four will need the allowlist updated alongside.

## Verification

Ran against a clean `rm -rf node_modules && npm ci`:

- No `allow-scripts` warning; `npm approve-scripts --allow-scripts-pending` reports "No packages with unreviewed install scripts"
- Scripts genuinely ran — confirmed `better_sqlite3.node` built, `@esbuild/linux-x64/bin/esbuild` present, Prisma engines fetched
- `npx prisma generate` → client generated
- `npm audit` → 0 vulnerabilities
- `npm run format:check` / `lint` / `typecheck` → clean
- `npm test` → 168 passed across 23 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)