### PR TITLE
docs: add the Next.js agent rules block to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,3 +102,17 @@ Avoid making commits that are too small. Especially `feat:` and `fix:` commits
 should be substantial enough to be meaningful in a changelog. Group related
 changes into a single commit rather than committing every minor edit. At the
 same time, keep changes sensibly sized — don't bundle unrelated work together.
+
+<!-- prettier-ignore-start -->
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->
+
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
`next dev` (Next.js 16.3.0) detects an AI coding agent on startup and writes a managed block into `AGENTS.md`, between `<!-- BEGIN:nextjs-agent-rules -->` / `<!-- END:nextjs-agent-rules -->` markers. It points agents at the version-matched docs bundled in `node_modules/next/dist/docs/`.

Provenance checked before committing: the lockfile integrity matches the registry for `next@16.3.0`, and `node_modules/next/dist/server/lib/generate-agent-files.js` is byte-identical to the published tarball. The write path is dev-only, gated on `agentRules !== false` in `next.config`, and touches nothing outside `AGENTS.md` / `CLAUDE.md`.

## Why the ignore comments

The block's paragraphs are long single lines, which collide with `proseWrap: "always"`:

- committed as-is → `format-check` fails;
- reflowed by Prettier → `hasCurrentAgentRules()` does an exact string comparison, sees a mismatch, and `next dev` rewrites the block unwrapped on the next start — a permanently dirty tree.

Wrapping it in `prettier-ignore-start` / `prettier-ignore-end` satisfies both sides. Next.js extracts only marker-to-marker, so the ignore comments are invisible to it.

## Verification

- `npm run format:check` passes.
- `hasCurrentAgentRules()` returns `true`.
- Forcing `writeAgentFiles()` returns `{ agentsMd: 'unchanged', claudeMd: 'skipped' }` and leaves the file byte-identical.
- The lint-staged pre-commit hook ran Prettier over the file and changed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)