### PR TITLE
fix: guard the daily article charts against an empty date range

### DIFF
--- a/src/lib/repository/statsRepository.ts
+++ b/src/lib/repository/statsRepository.ts
@@ -3,6 +3,7 @@
 import { ArticleStatus } from "@/generated/prisma/client";
 import prisma from "@/lib/prismaClient";
 import {
+  ArticlesPerFeedData,
   shapeArticlesPerFeedPerDay,
   shapeTokenUsage,
 } from "@/lib/repository/statsTransforms";
@@ -65,10 +66,23 @@ const getDaysInDateRange = (from: Date, to: Date) => {
   return dates;
 };
 
-/** The UTC span covering every day in `dates`, as a Prisma date filter. */
+/**
+ * The UTC span covering every day in `dates`, as a Prisma date filter. Callers
+ * must rule out an empty `dates` first — there is no span to build then.
+ */
 const utcRangeOf = (dates: string[]) => ({
   gte: `${dates[0]}T00:00:00.000Z`,
   lte: `${dates[dates.length - 1]}T23:59:59.999Z`,
+});
+
+/**
+ * What the daily-per-feed charts render for a range that covers no days, which
+ * `getDaysInDateRange` returns for an unparseable `from` or `to`.
+ */
+const noArticlesPerFeed = (): ArticlesPerFeedData => ({
+  rows: [],
+  feedKeys: [],
+  dailyAverage: 0,
 });
 
 const getFeedTitleById = async (userId: string) => {
@@ -86,6 +100,8 @@ const getFeedTitleById = async (userId: string) => {
 export const getWeeklyArticleCountPerFeed = async (from: Date, to: Date) => {
   const userId = await getUserId();
   const dates = getDaysInDateRange(from, to);
+
+  if (dates.length === 0) return noArticlesPerFeed();
 
   const [feedTitleById, articles] = await Promise.all([
     getFeedTitleById(userId),
@@ -116,6 +132,8 @@ const getStatusChangesPerFeedPerDay = async (
 ) => {
   const userId = await getUserId();
   const dates = getDaysInDateRange(from, to);
+
+  if (dates.length === 0) return noArticlesPerFeed();
 
   const [feedTitleById, articles] = await Promise.all([
     getFeedTitleById(userId),

--- a/tests/integration/statsRepository.test.ts
+++ b/tests/integration/statsRepository.test.ts
@@ -304,6 +304,27 @@ describe("statsRepository counts", () => {
     expect(rows).toEqual([{ date: "2026-02-10" }]);
   });
 
+  it("returns an empty chart when the range covers no days", async () => {
+    await createArticle({
+      userId,
+      feedId,
+      publicationDate: new Date("2026-02-10T06:00:00.000Z"),
+    });
+
+    const invalid = new Date("not a date");
+    const empty = { rows: [], feedKeys: [], dailyAverage: 0 };
+
+    await expect(
+      getWeeklyArticleCountPerFeed(invalid, invalid),
+    ).resolves.toEqual(empty);
+    await expect(getWeeklyArticlesRead(invalid, invalid)).resolves.toEqual(
+      empty,
+    );
+    await expect(getFilteredArticlesPerDay(invalid, invalid)).resolves.toEqual(
+      empty,
+    );
+  });
+
   it("reports token usage history by date and model", async () => {
     await prisma.tokenUsage.create({
       data: {


### PR DESCRIPTION
## What

`getWeeklyArticleCountPerFeed` and `getStatusChangesPerFeedPerDay` now return an empty chart when the requested range covers no days, instead of handing Prisma a malformed filter.

## Why

Folding the three daily charts onto one shared path (d7df267) moved the day list from a per-day `map` into a single range filter, so `utcRangeOf` indexes `dates[0]` / `dates[dates.length - 1]`. `getDaysInDateRange` returns `[]` for an unparseable `from` or `to` — the `from > to` guard is `false` for NaN, and `current <= to` is `false` so the loop never runs — which produced:

```
gte: "undefinedT00:00:00.000Z"
lte: "undefinedT23:59:59.999Z"
```

Prisma rejects that with `Invalid value for argument 'gte'` rather than rendering an empty chart. Before the refactor, the new-articles path degraded to empty rows via `dates.map`.

Found by `/code-review` on d7df267.

## Testing

`tests/integration/statsRepository.test.ts` gains a case covering all three chart entry points with an unparseable range; it reproduces the Prisma error before the fix. Full suite green: 262 tests, 28 files. `tsc --noEmit`, eslint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYJwHjJ4dxcRiiCyR9aPtK