### PR TITLE
fix: namespace the feed keys in the daily article rows

### DIFF
--- a/src/app/feed/stacked-feed-bar-chart.tsx
+++ b/src/app/feed/stacked-feed-bar-chart.tsx
@@ -6,7 +6,10 @@ import ChartCard from "@/app/feed/chart-card";
 import { ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { useDateFormatters } from "@/hooks/use-date-formatters";
 import { buildPalette } from "@/lib/charts/palette";
-import { ArticlesPerFeedData } from "@/lib/repository/statsTransforms";
+import {
+  ArticlesPerFeedData,
+  feedLabel,
+} from "@/lib/repository/statsTransforms";
 
 interface StackedFeedBarChartProps {
   title: string;
@@ -24,7 +27,7 @@ const StackedFeedBarChart = ({
   data,
 }: StackedFeedBarChartProps) => {
   const { short, long } = useDateFormatters();
-  const config = buildPalette(data?.feedKeys ?? []);
+  const config = buildPalette(data?.feedKeys ?? [], feedLabel);
 
   return (
     <ChartCard

--- a/src/lib/charts/palette.ts
+++ b/src/lib/charts/palette.ts
@@ -11,11 +11,19 @@ export const CHART_COLORS = [
   "var(--chart-8)",
 ] as const;
 
-export function buildPalette(keys: string[]): ChartConfig {
+/**
+ * A color per key, in `CHART_COLORS` order and wrapping around once the colors
+ * run out. Keys that are not meant to be read — a namespaced feed key, say —
+ * pass a `labelOf` to say what the legend and tooltip should show instead.
+ */
+export function buildPalette(
+  keys: string[],
+  labelOf: (key: string) => string = (key) => key,
+): ChartConfig {
   const config: Record<string, { label: string; color: string }> = {};
   keys.forEach((key, i) => {
     config[key] = {
-      label: key,
+      label: labelOf(key),
       color: CHART_COLORS[i % CHART_COLORS.length],
     };
   });

--- a/src/lib/repository/statsTransforms.ts
+++ b/src/lib/repository/statsTransforms.ts
@@ -8,6 +8,19 @@ export interface ArticlesPerFeedData {
   dailyAverage: number;
 }
 
+/**
+ * Feed titles share a row with the row's `date`, so they live behind a prefix
+ * no date key can collide with. `feedKey` and `feedLabel` are the only places
+ * that spell it out.
+ */
+const FEED_KEY_PREFIX = "feed:";
+
+/** The row key a feed's daily counts are filed under. */
+export const feedKey = (title: string) => `${FEED_KEY_PREFIX}${title}`;
+
+/** The feed title behind a row key, for chart legends and tooltips. */
+export const feedLabel = (key: string) => key.slice(FEED_KEY_PREFIX.length);
+
 /** An article reduced to the two fields the daily-per-feed charts need. */
 export interface DatedArticle {
   feedId: number;
@@ -25,9 +38,10 @@ export interface DatedArticle {
  * Callers pick which date an article is filed under — its publication date, or
  * the moment it became read or filtered — by mapping it into `at`.
  *
- * Feeds are keyed by title so the chart legend and tooltip read as feed names
- * without a second lookup. Articles of a feed the caller did not pass a title
- * for are dropped.
+ * Feeds are keyed by their title behind a prefix, so that a feed titled "date"
+ * cannot land on the row's own date key. Charts turn a key back into the title
+ * with `feedLabel`. Articles of a feed the caller did not pass a title for are
+ * dropped.
  */
 export function shapeArticlesPerFeedPerDay(
   dates: string[],
@@ -44,7 +58,9 @@ export function shapeArticlesPerFeedPerDay(
 
     if (!counts || title === undefined) return;
 
-    counts.set(title, (counts.get(title) ?? 0) + 1);
+    const key = feedKey(title);
+
+    counts.set(key, (counts.get(key) ?? 0) + 1);
   });
 
   const days = [...countsPerDay.values()];

--- a/tests/integration/statsRepository.test.ts
+++ b/tests/integration/statsRepository.test.ts
@@ -75,11 +75,11 @@ describe("statsRepository counts", () => {
     );
 
     expect(rows).toEqual([
-      { date: "2026-02-10", "Feed A": 1, "Feed B": 1 },
+      { date: "2026-02-10", "feed:Feed A": 1, "feed:Feed B": 1 },
       { date: "2026-02-11" },
-      { date: "2026-02-12", "Feed A": 1 },
+      { date: "2026-02-12", "feed:Feed A": 1 },
     ]);
-    expect(new Set(feedKeys)).toEqual(new Set(["Feed A", "Feed B"]));
+    expect(new Set(feedKeys)).toEqual(new Set(["feed:Feed A", "feed:Feed B"]));
     expect(dailyAverage).toBe(1);
   });
 
@@ -123,7 +123,7 @@ describe("statsRepository counts", () => {
       new Date("2026-02-10T00:00:00.000Z"),
     );
 
-    expect(rows).toEqual([{ date: "2026-02-10", "Feed A": 1 }]);
+    expect(rows).toEqual([{ date: "2026-02-10", "feed:Feed A": 1 }]);
   });
 
   it("splits the read articles of a day across their feeds", async () => {
@@ -153,8 +153,10 @@ describe("statsRepository counts", () => {
       new Date("2026-02-10T00:00:00.000Z"),
     );
 
-    expect(rows).toEqual([{ date: "2026-02-10", "Feed A": 1, "Feed B": 2 }]);
-    expect(new Set(feedKeys)).toEqual(new Set(["Feed A", "Feed B"]));
+    expect(rows).toEqual([
+      { date: "2026-02-10", "feed:Feed A": 1, "feed:Feed B": 2 },
+    ]);
+    expect(new Set(feedKeys)).toEqual(new Set(["feed:Feed A", "feed:Feed B"]));
     expect(dailyAverage).toBe(3);
   });
 
@@ -204,7 +206,7 @@ describe("statsRepository counts", () => {
       new Date("2026-02-10T00:00:00.000Z"),
     );
 
-    expect(rows).toEqual([{ date: "2026-02-10", "Feed A": 3 }]);
+    expect(rows).toEqual([{ date: "2026-02-10", "feed:Feed A": 3 }]);
     expect(dailyAverage).toBe(3);
   });
 
@@ -229,8 +231,10 @@ describe("statsRepository counts", () => {
       new Date("2026-02-10T00:00:00.000Z"),
     );
 
-    expect(rows).toEqual([{ date: "2026-02-10", "Feed A": 1, "Feed B": 1 }]);
-    expect(new Set(feedKeys)).toEqual(new Set(["Feed A", "Feed B"]));
+    expect(rows).toEqual([
+      { date: "2026-02-10", "feed:Feed A": 1, "feed:Feed B": 1 },
+    ]);
+    expect(new Set(feedKeys)).toEqual(new Set(["feed:Feed A", "feed:Feed B"]));
   });
 
   it("leaves unread and read articles out of the rejected counts", async () => {
@@ -278,9 +282,9 @@ describe("statsRepository counts", () => {
     );
 
     expect(rows).toEqual([
-      { date: "2026-02-10", "Feed A": 1 },
+      { date: "2026-02-10", "feed:Feed A": 1 },
       { date: "2026-02-11" },
-      { date: "2026-02-12", "Feed A": 1 },
+      { date: "2026-02-12", "feed:Feed A": 1 },
     ]);
     expect(dailyAverage).toBeCloseTo(2 / 3);
   });

--- a/tests/integration/statsRepository.test.ts
+++ b/tests/integration/statsRepository.test.ts
@@ -103,6 +103,32 @@ describe("statsRepository counts", () => {
     expect(rows).toEqual([{ date: "2026-02-10" }]);
   });
 
+  it("counts new articles sitting exactly on the range bounds", async () => {
+    // SQLite keeps these as text with a "+00:00" offset, so a hand-rolled
+    // string comparison against a "...Z" bound would sort the midnight article
+    // below it and drop it. Prisma normalizes both sides; this pins that.
+    await createArticle({
+      userId,
+      feedId,
+      publicationDate: new Date("2026-02-10T00:00:00.000Z"),
+    });
+    await createArticle({
+      userId,
+      feedId,
+      publicationDate: new Date("2026-02-11T23:59:59.999Z"),
+    });
+
+    const { rows } = await getWeeklyArticleCountPerFeed(
+      new Date("2026-02-10T00:00:00.000Z"),
+      new Date("2026-02-11T00:00:00.000Z"),
+    );
+
+    expect(rows).toEqual([
+      { date: "2026-02-10", "feed:Feed A": 1 },
+      { date: "2026-02-11", "feed:Feed A": 1 },
+    ]);
+  });
+
   it("counts read articles but not hand-rejected ones as read that day", async () => {
     const day = new Date("2026-02-10T12:00:00.000Z");
     await createArticle({

--- a/tests/unit/palette.test.ts
+++ b/tests/unit/palette.test.ts
@@ -30,6 +30,15 @@ describe("buildPalette", () => {
     });
   });
 
+  it("labels each key with labelOf when one is given", () => {
+    const palette = buildPalette(["feed:a", "feed:b"], (key) => key.slice(5));
+    expect(palette["feed:a"]).toEqual({
+      label: "a",
+      color: "var(--chart-1)",
+    });
+    expect(palette["feed:b"].label).toBe("b");
+  });
+
   it("wraps around when there are more keys than colors", () => {
     const keys = Array.from({ length: 10 }, (_, i) => `k${i}`);
     const palette = buildPalette(keys);

--- a/tests/unit/statsTransforms.test.ts
+++ b/tests/unit/statsTransforms.test.ts
@@ -1,5 +1,7 @@
 import { TokenUsage } from "@/generated/prisma/client";
 import {
+  feedKey,
+  feedLabel,
   shapeArticlesPerFeedPerDay,
   shapeTokenUsage,
 } from "@/lib/repository/statsTransforms";
@@ -57,8 +59,10 @@ describe("shapeArticlesPerFeedPerDay", () => {
       feedTitles,
     );
 
-    expect(rows).toEqual([{ date: "2026-03-01", "Feed A": 2, "Feed B": 1 }]);
-    expect(new Set(feedKeys)).toEqual(new Set(["Feed A", "Feed B"]));
+    expect(rows).toEqual([
+      { date: "2026-03-01", "feed:Feed A": 2, "feed:Feed B": 1 },
+    ]);
+    expect(new Set(feedKeys)).toEqual(new Set(["feed:Feed A", "feed:Feed B"]));
     expect(dailyAverage).toBe(3);
   });
 
@@ -73,9 +77,9 @@ describe("shapeArticlesPerFeedPerDay", () => {
     );
 
     expect(rows).toEqual([
-      { date: "2026-03-01", "Feed A": 1 },
+      { date: "2026-03-01", "feed:Feed A": 1 },
       { date: "2026-03-02" },
-      { date: "2026-03-03", "Feed B": 1 },
+      { date: "2026-03-03", "feed:Feed B": 1 },
     ]);
     expect(dailyAverage).toBeCloseTo(2 / 3);
   });
@@ -91,7 +95,7 @@ describe("shapeArticlesPerFeedPerDay", () => {
       feedTitles,
     );
 
-    expect(rows).toEqual([{ date: "2026-03-02", "Feed A": 1 }]);
+    expect(rows).toEqual([{ date: "2026-03-02", "feed:Feed A": 1 }]);
   });
 
   it("drops articles of a feed without a known title", () => {
@@ -105,6 +109,17 @@ describe("shapeArticlesPerFeedPerDay", () => {
     expect(feedKeys).toEqual([]);
   });
 
+  it('keeps a feed titled "date" out of the row\'s own date key', () => {
+    const { rows, feedKeys } = shapeArticlesPerFeedPerDay(
+      ["2026-03-01"],
+      [article("2026-03-01T08:00:00.000Z", 3)],
+      new Map([[3, "date"]]),
+    );
+
+    expect(rows).toEqual([{ date: "2026-03-01", "feed:date": 1 }]);
+    expect(feedKeys).toEqual(["feed:date"]);
+  });
+
   it("buckets by UTC day, not by the host timezone", () => {
     const { rows } = shapeArticlesPerFeedPerDay(
       ["2026-03-01", "2026-03-02"],
@@ -113,9 +128,20 @@ describe("shapeArticlesPerFeedPerDay", () => {
     );
 
     expect(rows).toEqual([
-      { date: "2026-03-01", "Feed A": 1 },
+      { date: "2026-03-01", "feed:Feed A": 1 },
       { date: "2026-03-02" },
     ]);
+  });
+});
+
+describe("feedKey / feedLabel", () => {
+  it("round-trips a title through its row key", () => {
+    expect(feedLabel(feedKey("Feed A"))).toBe("Feed A");
+  });
+
+  it("round-trips a title that collides with the date key", () => {
+    expect(feedKey("date")).not.toBe("date");
+    expect(feedLabel(feedKey("date"))).toBe("date");
   });
 });
 


### PR DESCRIPTION
Closes the two remaining findings from `/code-review` on d7df267.

## 1. A feed titled `date` corrupted the chart (`1764c3c`)

Daily rows carry `date` alongside one key per feed title, so a feed literally titled `date` overwrote the row's own date with its count — `XAxis dataKey="date"` then formatted `new Date(3)` and every bar landed in 1970. Deriving `feedKeys` from the counts map (rather than filtering `date` out of them, as the pre-refactor code did) also gave that feed a bogus `<Bar>`.

Feed counts now live behind a `feed:` prefix that no date key can collide with:

```
{ date: "2026-03-01", "feed:Feed A": 2, "feed:Feed B": 1 }
```

`buildPalette` gained an optional `labelOf`, so the legend and tooltip still read as plain feed titles.

## 2. The `findMany` on the new-articles query stays — with a test (`c4f04ab`)

The review suggested aggregating in the database instead of counting fetched rows in JS. I looked and left it alone, for two reasons:

- **The rows never reach the browser.** `shapeArticlesPerFeedPerDay` runs server-side, so only ~90 shaped rows cross the server-action boundary. The cost is SQLite → Node, on a local file, for two columns.
- **A raw `GROUP BY` has a real correctness trap.** Prisma 7 stores SQLite `DateTime` as text with a `+00:00` offset:

  ```
  stored:  2026-02-10T00:00:00.000+00:00
  bound:   2026-02-10T00:00:00.000Z
  TEXT compare at char 24:  '+' (0x2B) < 'Z' (0x5A)   =>  midnight article DROPPED
  ```

  Dodging that means hand-encoding Prisma's internal format or wrapping the column in `datetime()`, which forfeits any index on `publicationDate`.

So instead of the rewrite, this adds a test pinning that articles on both range bounds stay counted — it fails the moment such a rewrite loses either one.

## Testing

266 tests green (28 files), `tsc --noEmit`, eslint, prettier, and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYJwHjJ4dxcRiiCyR9aPtK